### PR TITLE
Ensure API log directory exists at startup

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/config/LogDirectoryInitializer.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/config/LogDirectoryInitializer.java
@@ -1,0 +1,55 @@
+package com.opyruso.nwleaderboard.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import io.quarkus.runtime.Startup;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@Singleton
+@Startup
+public class LogDirectoryInitializer {
+
+    private static final Logger LOG = Logger.getLogger(LogDirectoryInitializer.class);
+
+    @ConfigProperty(name = "quarkus.log.file.enable", defaultValue = "false")
+    boolean fileLoggingEnabled;
+
+    @ConfigProperty(name = "quarkus.log.file.path", defaultValue = "")
+    String logFilePath;
+
+    @PostConstruct
+    void initLogDirectory() {
+        if (!fileLoggingEnabled) {
+            return;
+        }
+
+        if (logFilePath == null || logFilePath.isBlank()) {
+            LOG.warn("File logging is enabled but no log file path has been configured.");
+            return;
+        }
+
+        Path logFile = Paths.get(logFilePath).toAbsolutePath();
+        Path logDirectory = logFile.getParent();
+        if (logDirectory == null) {
+            return;
+        }
+
+        if (Files.exists(logDirectory)) {
+            return;
+        }
+
+        try {
+            Files.createDirectories(logDirectory);
+            LOG.debugf("Created log directory %s", logDirectory);
+        } catch (IOException | SecurityException e) {
+            LOG.warnf(e, "Unable to create log directory %s for file logging", logDirectory);
+        }
+    }
+}

--- a/nwleaderboard-api/src/main/resources/application.properties
+++ b/nwleaderboard-api/src/main/resources/application.properties
@@ -13,7 +13,7 @@ quarkus.log.console.level=DEBUG
 quarkus.log.file.level=INFO
 quarkus.log.file.enable=true
 quarkus.log.file.format=%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1} [%p] %m%n
-quarkus.log.file.path=/var/log/quarkus/nwleaderboard-api-dev.log
+quarkus.log.file.path=/var/log/quarkus/nwleaderboard/nwleaderboard-api-dev.log
 quarkus.log.file.rotation.max-file-size=100M
 quarkus.log.file.rotation.max-backup-index=3
 


### PR DESCRIPTION
## Summary
- add a startup bean that creates the parent directory for the configured Quarkus log file when file logging is enabled
- warn when file logging is enabled without a configured destination so the deployment can be fixed quickly

## Testing
- `mvn -q test` *(fails: unable to reach repo.maven.apache.org to resolve the Quarkus BOM)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe605316c832ca1ba0e2766a45b50