### PR TITLE
feat: enhance password flows and input styling

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -87,10 +87,18 @@ body[data-theme='light'] .highlight-list {
   font-size: 1.1rem;
 }
 
+.form-field {
+  position: relative;
+}
+
 .form-field span,
 .form-checkbox span {
   margin-bottom: 0.5rem;
   letter-spacing: 1px;
+}
+
+.form-checkbox span {
+  margin-bottom: 0;
 }
 
 .form-field input,
@@ -100,6 +108,20 @@ body[data-theme='light'] .highlight-list {
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(0, 0, 0, 0.35);
   color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.form-field input::placeholder {
+  color: transparent;
+}
+
+.form-field input:focus,
+.form-field select:focus {
+  outline: none;
+  border-color: rgba(158, 197, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(158, 197, 255, 0.2);
 }
 
 body[data-theme='light'] .form-field input,
@@ -110,6 +132,40 @@ body[data-theme='light'] .form-field select {
 
 .form-field select {
   cursor: pointer;
+}
+
+.form-field-floating span {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-bottom: 0;
+  letter-spacing: 0.5px;
+  pointer-events: none;
+  transition: transform 0.2s ease, top 0.2s ease, font-size 0.2s ease, opacity 0.2s ease;
+  opacity: 0.8;
+  background: transparent;
+}
+
+.form-field-floating input {
+  padding: 1.1rem 1rem 0.5rem;
+}
+
+.form-field-floating input:focus + span,
+.form-field-floating input:not(:placeholder-shown) + span {
+  top: 0.55rem;
+  transform: translateY(0);
+  font-size: 0.7rem;
+  opacity: 0.65;
+}
+
+body[data-theme='light'] .form-field-floating span {
+  opacity: 0.75;
+}
+
+body[data-theme='light'] .form-field-floating input:focus + span,
+body[data-theme='light'] .form-field-floating input:not(:placeholder-shown) + span {
+  opacity: 0.6;
 }
 
 .form-checkbox {

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -15,6 +15,9 @@ const en = {
   rememberMe: 'Remember me',
   username: 'Username',
   passwordLabel: 'Password',
+  currentPassword: 'Current password',
+  newPassword: 'New password',
+  confirmPassword: 'Confirm password',
   loginDescription:
     'Sign in to synchronise your favourite builds and compare them with the community.',
   loginAction: 'Continue',
@@ -32,6 +35,7 @@ const en = {
   registerUsernameTaken: 'This username is already in use.',
   registerEmailTaken: 'This email is already registered.',
   registerError: 'We were unable to create your account. Please try again later.',
+  passwordMismatch: 'The passwords do not match. Please try again.',
   forgotDescription:
     'Enter the email linked to your account and we will send you instructions to reset your password.',
   forgotAction: 'Send reset link',
@@ -43,8 +47,12 @@ const en = {
     'Customise your experience. These settings are stored locally on this device.',
   preferencesSaved: 'Preferences updated',
   passwordDescription:
-    'Password updates are available from the secure account portal.',
-  passwordAction: 'Open account portal',
+    'Update your password securely from this page. Enter your current password and choose a new one.',
+  passwordAction: 'Update password',
+  passwordSuccess: 'Your password has been updated successfully.',
+  passwordCurrentInvalid: 'The current password is incorrect.',
+  passwordError:
+    'We were unable to update your password. Please try again later.',
   themeToggle: 'Toggle theme',
   versionChecking: 'Checking for updates…',
   versionUpToDate: 'You are using the latest version.',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -15,6 +15,9 @@ const fr = {
   rememberMe: 'Se souvenir de moi',
   username: "Nom d'utilisateur",
   passwordLabel: 'Mot de passe',
+  currentPassword: 'Mot de passe actuel',
+  newPassword: 'Nouveau mot de passe',
+  confirmPassword: 'Confirmer le mot de passe',
   loginDescription:
     'Connectez-vous pour synchroniser vos builds favoris et les comparer avec la communauté.',
   loginAction: 'Continuer',
@@ -33,6 +36,7 @@ const fr = {
   registerEmailTaken: 'Cette adresse e-mail est déjà enregistrée.',
   registerError:
     "Impossible de créer votre compte pour le moment. Veuillez réessayer plus tard.",
+  passwordMismatch: 'Les mots de passe ne correspondent pas. Merci de réessayer.',
   forgotDescription:
     'Indiquez l’adresse e-mail liée à votre compte pour recevoir les instructions de réinitialisation.',
   forgotAction: 'Envoyer le lien',
@@ -44,8 +48,12 @@ const fr = {
     'Personnalisez votre expérience. Ces réglages sont stockés localement sur cet appareil.',
   preferencesSaved: 'Préférences enregistrées',
   passwordDescription:
-    'Les modifications de mot de passe sont disponibles depuis le portail sécurisé.',
-  passwordAction: 'Ouvrir le portail de compte',
+    'Modifiez votre mot de passe en toute sécurité depuis cette page. Indiquez votre mot de passe actuel puis choisissez-en un nouveau.',
+  passwordAction: 'Mettre à jour le mot de passe',
+  passwordSuccess: 'Votre mot de passe a été mis à jour avec succès.',
+  passwordCurrentInvalid: 'Le mot de passe actuel est incorrect.',
+  passwordError:
+    "Impossible de mettre à jour votre mot de passe pour le moment. Veuillez réessayer plus tard.",
   themeToggle: 'Changer de thème',
   versionChecking: 'Recherche de mises à jour…',
   versionUpToDate: 'Vous utilisez la dernière version.',

--- a/nwleaderboard-ui/js/pages/ForgotPassword.js
+++ b/nwleaderboard-ui/js/pages/ForgotPassword.js
@@ -44,16 +44,17 @@ export default function ForgotPassword() {
       </h1>
       <p className="page-description">{t.forgotDescription}</p>
       <form className="form" onSubmit={handleSubmit}>
-        <label className="form-field">
-          <span>{t.email}</span>
+        <label className="form-field form-field-floating">
           <input
             name="email"
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             autoComplete="email"
+            placeholder=" "
             required
           />
+          <span>{t.email}</span>
         </label>
         <div className="form-actions">
           <button type="submit" disabled={status === 'loading'}>

--- a/nwleaderboard-ui/js/pages/Login.js
+++ b/nwleaderboard-ui/js/pages/Login.js
@@ -29,6 +29,10 @@ export default function Login({ onLogin }) {
     }));
   };
 
+  const preventCopyPaste = (event) => {
+    event.preventDefault();
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
     setStatus('loading');
@@ -95,27 +99,32 @@ export default function Login({ onLogin }) {
       </h1>
       <p className="page-description">{t.loginDescription}</p>
       <form className="form" onSubmit={handleSubmit}>
-        <label className="form-field">
-          <span>{t.username}</span>
+        <label className="form-field form-field-floating">
           <input
             name="username"
             type="text"
             value={form.username}
             onChange={updateField}
             autoComplete="username"
+            placeholder=" "
             required
           />
+          <span>{t.username}</span>
         </label>
-        <label className="form-field">
-          <span>{t.passwordLabel}</span>
+        <label className="form-field form-field-floating">
           <input
             name="password"
             type="password"
             value={form.password}
             onChange={updateField}
             autoComplete="current-password"
+            onCopy={preventCopyPaste}
+            onCut={preventCopyPaste}
+            onPaste={preventCopyPaste}
+            placeholder=" "
             required
           />
+          <span>{t.passwordLabel}</span>
         </label>
         <label className="form-checkbox">
           <input

--- a/nwleaderboard-ui/js/pages/Password.js
+++ b/nwleaderboard-ui/js/pages/Password.js
@@ -3,12 +3,70 @@ import { LangContext } from '../i18n.js';
 export default function Password() {
   const { t } = React.useContext(LangContext);
 
-  const openAccount = () => {
-    const baseUrl = window.CONFIG['auth-url'] || '';
-    const trimmedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-    const realm = window.CONFIG['auth-realm'];
-    const accountUrl = `${trimmedBase}/realms/${realm}/account`;
-    window.open(accountUrl, '_blank', 'noopener');
+  const [form, setForm] = React.useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: '',
+  });
+  const [status, setStatus] = React.useState('idle');
+  const [message, setMessage] = React.useState('');
+
+  const updateField = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const preventCopyPaste = (event) => {
+    event.preventDefault();
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setStatus('loading');
+    setMessage('');
+
+    if (form.newPassword !== form.confirmPassword) {
+      setStatus('error');
+      setMessage(t.passwordMismatch);
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `${window.CONFIG['nwleaderboard-api-url']}/user/password`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            currentPassword: form.currentPassword,
+            newPassword: form.newPassword,
+          }),
+        }
+      );
+
+      if (response.status === 401) {
+        setStatus('error');
+        setMessage(t.passwordCurrentInvalid);
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error('password update failed');
+      }
+
+      setStatus('success');
+      setMessage(t.passwordSuccess);
+      setForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+    } catch (error) {
+      console.error('Unable to update password', error);
+      setStatus('error');
+      setMessage(t.passwordError);
+    }
   };
 
   return (
@@ -17,11 +75,63 @@ export default function Password() {
         {t.password}
       </h1>
       <p className="page-description">{t.passwordDescription}</p>
-      <div className="form-actions">
-        <button type="button" onClick={openAccount}>
-          {t.passwordAction}
-        </button>
-      </div>
+      <form className="form" onSubmit={handleSubmit}>
+        <label className="form-field form-field-floating">
+          <input
+            name="currentPassword"
+            type="password"
+            value={form.currentPassword}
+            onChange={updateField}
+            autoComplete="current-password"
+            onCopy={preventCopyPaste}
+            onCut={preventCopyPaste}
+            onPaste={preventCopyPaste}
+            placeholder=" "
+            required
+          />
+          <span>{t.currentPassword}</span>
+        </label>
+        <label className="form-field form-field-floating">
+          <input
+            name="newPassword"
+            type="password"
+            value={form.newPassword}
+            onChange={updateField}
+            autoComplete="new-password"
+            onCopy={preventCopyPaste}
+            onCut={preventCopyPaste}
+            onPaste={preventCopyPaste}
+            placeholder=" "
+            required
+          />
+          <span>{t.newPassword}</span>
+        </label>
+        <label className="form-field form-field-floating">
+          <input
+            name="confirmPassword"
+            type="password"
+            value={form.confirmPassword}
+            onChange={updateField}
+            autoComplete="new-password"
+            onCopy={preventCopyPaste}
+            onCut={preventCopyPaste}
+            onPaste={preventCopyPaste}
+            placeholder=" "
+            required
+          />
+          <span>{t.confirmPassword}</span>
+        </label>
+        <div className="form-actions">
+          <button type="submit" disabled={status === 'loading'}>
+            {status === 'loading' ? '…' : t.passwordAction}
+          </button>
+        </div>
+      </form>
+      {message ? (
+        <p className="form-message" role="status">
+          {message}
+        </p>
+      ) : null}
     </main>
   );
 }

--- a/nwleaderboard-ui/js/pages/Register.js
+++ b/nwleaderboard-ui/js/pages/Register.js
@@ -6,6 +6,7 @@ export default function Register() {
     username: '',
     email: '',
     password: '',
+    confirmPassword: '',
   });
   const [status, setStatus] = React.useState('idle');
   const [message, setMessage] = React.useState('');
@@ -18,10 +19,20 @@ export default function Register() {
     }));
   };
 
+  const preventCopyPaste = (event) => {
+    event.preventDefault();
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
     setStatus('loading');
     setMessage('');
+
+    if (form.password !== form.confirmPassword) {
+      setStatus('error');
+      setMessage(t.passwordMismatch);
+      return;
+    }
 
     try {
       const response = await fetch(
@@ -66,7 +77,7 @@ export default function Register() {
 
       setStatus('success');
       setMessage(t.registerSuccess);
-      setForm({ username: '', email: '', password: '' });
+      setForm({ username: '', email: '', password: '', confirmPassword: '' });
     } catch (error) {
       console.error('Unable to register user', error);
       setStatus('error');
@@ -81,38 +92,59 @@ export default function Register() {
       </h1>
       <p className="page-description">{t.registerDescription}</p>
       <form className="form" onSubmit={handleSubmit}>
-        <label className="form-field">
-          <span>{t.username}</span>
+        <label className="form-field form-field-floating">
           <input
             name="username"
             type="text"
             value={form.username}
             onChange={updateField}
             autoComplete="username"
+            placeholder=" "
             required
           />
+          <span>{t.username}</span>
         </label>
-        <label className="form-field">
-          <span>{t.email}</span>
+        <label className="form-field form-field-floating">
           <input
             name="email"
             type="email"
             value={form.email}
             onChange={updateField}
             autoComplete="email"
+            placeholder=" "
             required
           />
+          <span>{t.email}</span>
         </label>
-        <label className="form-field">
-          <span>{t.passwordLabel}</span>
+        <label className="form-field form-field-floating">
           <input
             name="password"
             type="password"
             value={form.password}
             onChange={updateField}
             autoComplete="new-password"
+            onCopy={preventCopyPaste}
+            onCut={preventCopyPaste}
+            onPaste={preventCopyPaste}
+            placeholder=" "
             required
           />
+          <span>{t.passwordLabel}</span>
+        </label>
+        <label className="form-field form-field-floating">
+          <input
+            name="confirmPassword"
+            type="password"
+            value={form.confirmPassword}
+            onChange={updateField}
+            autoComplete="new-password"
+            onCopy={preventCopyPaste}
+            onCut={preventCopyPaste}
+            onPaste={preventCopyPaste}
+            placeholder=" "
+            required
+          />
+          <span>{t.confirmPassword}</span>
         </label>
         <div className="form-actions">
           <button type="submit" disabled={status === 'loading'}>


### PR DESCRIPTION
## Summary
- implement floating placeholder styling for form inputs and disable copy/paste on password fields
- add password confirmation to registration and in-app password update flows with refreshed translations
- expose an internal password update endpoint that verifies the current credential before updating

## Testing
- npm run build
- mvn -q test *(fails: Maven Central unreachable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe59f10e8832cb8263df16eb5d73f