### PR TITLE
Add entities for leaderboard tables with auditing

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Dungeon.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Dungeon.java
@@ -1,0 +1,117 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing a dungeon.
+ */
+@Entity
+@Table(name = "dungeon")
+public class Dungeon extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_dungeon")
+    private Long id;
+
+    @Column(name = "name_local_en", nullable = false)
+    private String nameLocalEn;
+
+    @Column(name = "name_local_fr", nullable = false)
+    private String nameLocalFr;
+
+    @Column(name = "name_local_de", nullable = false)
+    private String nameLocalDe;
+
+    @Column(name = "name_local_es", nullable = false)
+    private String nameLocalEs;
+
+    @Column(name = "name_local_esmx", nullable = false)
+    private String nameLocalEsmx;
+
+    @Column(name = "name_local_it", nullable = false)
+    private String nameLocalIt;
+
+    @Column(name = "name_local_pl", nullable = false)
+    private String nameLocalPl;
+
+    @Column(name = "name_local_pt", nullable = false)
+    private String nameLocalPt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNameLocalEn() {
+        return nameLocalEn;
+    }
+
+    public void setNameLocalEn(String nameLocalEn) {
+        this.nameLocalEn = nameLocalEn;
+    }
+
+    public String getNameLocalFr() {
+        return nameLocalFr;
+    }
+
+    public void setNameLocalFr(String nameLocalFr) {
+        this.nameLocalFr = nameLocalFr;
+    }
+
+    public String getNameLocalDe() {
+        return nameLocalDe;
+    }
+
+    public void setNameLocalDe(String nameLocalDe) {
+        this.nameLocalDe = nameLocalDe;
+    }
+
+    public String getNameLocalEs() {
+        return nameLocalEs;
+    }
+
+    public void setNameLocalEs(String nameLocalEs) {
+        this.nameLocalEs = nameLocalEs;
+    }
+
+    public String getNameLocalEsmx() {
+        return nameLocalEsmx;
+    }
+
+    public void setNameLocalEsmx(String nameLocalEsmx) {
+        this.nameLocalEsmx = nameLocalEsmx;
+    }
+
+    public String getNameLocalIt() {
+        return nameLocalIt;
+    }
+
+    public void setNameLocalIt(String nameLocalIt) {
+        this.nameLocalIt = nameLocalIt;
+    }
+
+    public String getNameLocalPl() {
+        return nameLocalPl;
+    }
+
+    public void setNameLocalPl(String nameLocalPl) {
+        this.nameLocalPl = nameLocalPl;
+    }
+
+    public String getNameLocalPt() {
+        return nameLocalPt;
+    }
+
+    public void setNameLocalPt(String nameLocalPt) {
+        this.nameLocalPt = nameLocalPt;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Player.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Player.java
@@ -1,0 +1,40 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing a player.
+ */
+@Entity
+@Table(name = "player")
+public class Player extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_player")
+    private Long id;
+
+    @Column(name = "playername", nullable = false, unique = true)
+    private String playerName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunScore.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunScore.java
@@ -1,0 +1,66 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing the score achieved for a dungeon run.
+ */
+@Entity
+@Table(name = "run_score")
+public class RunScore extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_run")
+    private Long id;
+
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_dungeon", nullable = false)
+    private Dungeon dungeon;
+
+    @Column(name = "score", nullable = false)
+    private Integer score;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getWeek() {
+        return week;
+    }
+
+    public void setWeek(Integer week) {
+        this.week = week;
+    }
+
+    public Dungeon getDungeon() {
+        return dungeon;
+    }
+
+    public void setDungeon(Dungeon dungeon) {
+        this.dungeon = dungeon;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    public void setScore(Integer score) {
+        this.score = score;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunScorePlayer.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunScorePlayer.java
@@ -1,0 +1,54 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+/**
+ * Association between a run score and the participating players.
+ */
+@Entity
+@Table(name = "run_score_player")
+public class RunScorePlayer extends Auditable {
+
+    @EmbeddedId
+    private RunScorePlayerId id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("runId")
+    @JoinColumn(name = "id_run", nullable = false)
+    private RunScore runScore;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("playerId")
+    @JoinColumn(name = "id_player", nullable = false)
+    private Player player;
+
+    public RunScorePlayerId getId() {
+        return id;
+    }
+
+    public void setId(RunScorePlayerId id) {
+        this.id = id;
+    }
+
+    public RunScore getRunScore() {
+        return runScore;
+    }
+
+    public void setRunScore(RunScore runScore) {
+        this.runScore = runScore;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public void setPlayer(Player player) {
+        this.player = player;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunScorePlayerId.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunScorePlayerId.java
@@ -1,0 +1,61 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Composite identifier for the run_score_player association table.
+ */
+@Embeddable
+public class RunScorePlayerId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "id_run")
+    private Long runId;
+
+    @Column(name = "id_player")
+    private Long playerId;
+
+    public RunScorePlayerId() {
+    }
+
+    public RunScorePlayerId(Long runId, Long playerId) {
+        this.runId = runId;
+        this.playerId = playerId;
+    }
+
+    public Long getRunId() {
+        return runId;
+    }
+
+    public void setRunId(Long runId) {
+        this.runId = runId;
+    }
+
+    public Long getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(Long playerId) {
+        this.playerId = playerId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RunScorePlayerId that)) {
+            return false;
+        }
+        return Objects.equals(runId, that.runId) && Objects.equals(playerId, that.playerId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(runId, playerId);
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunTime.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunTime.java
@@ -1,0 +1,66 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing the completion time for a dungeon run.
+ */
+@Entity
+@Table(name = "run_time")
+public class RunTime extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_run")
+    private Long id;
+
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_dungeon", nullable = false)
+    private Dungeon dungeon;
+
+    @Column(name = "time_in_second", nullable = false)
+    private Integer timeInSecond;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Integer getWeek() {
+        return week;
+    }
+
+    public void setWeek(Integer week) {
+        this.week = week;
+    }
+
+    public Dungeon getDungeon() {
+        return dungeon;
+    }
+
+    public void setDungeon(Dungeon dungeon) {
+        this.dungeon = dungeon;
+    }
+
+    public Integer getTimeInSecond() {
+        return timeInSecond;
+    }
+
+    public void setTimeInSecond(Integer timeInSecond) {
+        this.timeInSecond = timeInSecond;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunTimePlayer.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunTimePlayer.java
@@ -1,0 +1,54 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+/**
+ * Association between a run time and the participating players.
+ */
+@Entity
+@Table(name = "run_time_player")
+public class RunTimePlayer extends Auditable {
+
+    @EmbeddedId
+    private RunTimePlayerId id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("runId")
+    @JoinColumn(name = "id_run", nullable = false)
+    private RunTime runTime;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId("playerId")
+    @JoinColumn(name = "id_player", nullable = false)
+    private Player player;
+
+    public RunTimePlayerId getId() {
+        return id;
+    }
+
+    public void setId(RunTimePlayerId id) {
+        this.id = id;
+    }
+
+    public RunTime getRunTime() {
+        return runTime;
+    }
+
+    public void setRunTime(RunTime runTime) {
+        this.runTime = runTime;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public void setPlayer(Player player) {
+        this.player = player;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunTimePlayerId.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/RunTimePlayerId.java
@@ -1,0 +1,61 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Composite identifier for the run_time_player association table.
+ */
+@Embeddable
+public class RunTimePlayerId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "id_run")
+    private Long runId;
+
+    @Column(name = "id_player")
+    private Long playerId;
+
+    public RunTimePlayerId() {
+    }
+
+    public RunTimePlayerId(Long runId, Long playerId) {
+        this.runId = runId;
+        this.playerId = playerId;
+    }
+
+    public Long getRunId() {
+        return runId;
+    }
+
+    public void setRunId(Long runId) {
+        this.runId = runId;
+    }
+
+    public Long getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(Long playerId) {
+        this.playerId = playerId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RunTimePlayerId that)) {
+            return false;
+        }
+        return Objects.equals(runId, that.runId) && Objects.equals(playerId, that.playerId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(runId, playerId);
+    }
+}


### PR DESCRIPTION
## Summary
- add JPA entities for player, dungeon, run_score, run_time and their player associations
- include composite identifier classes for run score/time players and inherit audit columns from the shared base class

## Testing
- `mvn -f nwleaderboard-api/pom.xml -q test` *(fails: dependency resolution blocked by offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cff272d454832c957130e15f8ab758