### PR TITLE
Add leaderboard score and time endpoints

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
@@ -1,0 +1,48 @@
+package com.opyruso.nwleaderboard;
+
+import com.opyruso.nwleaderboard.dto.ScoreLeaderboardEntryResponse;
+import com.opyruso.nwleaderboard.dto.TimeLeaderboardEntryResponse;
+import com.opyruso.nwleaderboard.service.LeaderboardService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+
+/**
+ * REST resource exposing leaderboard data for score and time views.
+ */
+@Path("/leaderboard")
+@Produces(MediaType.APPLICATION_JSON)
+public class LeaderboardResource {
+
+    @Inject
+    LeaderboardService leaderboardService;
+
+    @GET
+    @Path("/score")
+    public List<ScoreLeaderboardEntryResponse> score(@QueryParam("dungeonId") Long dungeonId) {
+        long id = requireDungeonId(dungeonId);
+        return leaderboardService.getScoreLeaderboard(id);
+    }
+
+    @GET
+    @Path("/time")
+    public List<TimeLeaderboardEntryResponse> time(@QueryParam("dungeonId") Long dungeonId) {
+        long id = requireDungeonId(dungeonId);
+        return leaderboardService.getTimeLeaderboard(id);
+    }
+
+    private long requireDungeonId(Long dungeonId) {
+        if (dungeonId == null) {
+            throw new BadRequestException("Query parameter 'dungeonId' is required");
+        }
+        if (dungeonId.longValue() <= 0) {
+            throw new BadRequestException("Query parameter 'dungeonId' must be greater than zero");
+        }
+        return dungeonId;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ScoreLeaderboardEntryResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ScoreLeaderboardEntryResponse.java
@@ -1,0 +1,13 @@
+package com.opyruso.nwleaderboard.dto;
+
+import java.util.List;
+
+/**
+ * Response payload describing a leaderboard entry ordered by score.
+ *
+ * @param id      unique identifier of the dungeon run
+ * @param week    week number for which the score was recorded
+ * @param score   total score achieved by the party
+ * @param players list of player display names participating in the run
+ */
+public record ScoreLeaderboardEntryResponse(Long id, Integer week, Integer score, List<String> players) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/TimeLeaderboardEntryResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/TimeLeaderboardEntryResponse.java
@@ -1,0 +1,13 @@
+package com.opyruso.nwleaderboard.dto;
+
+import java.util.List;
+
+/**
+ * Response payload describing a leaderboard entry ordered by completion time.
+ *
+ * @param id      unique identifier of the dungeon run
+ * @param week    week number for which the time was recorded
+ * @param time    completion time expressed in seconds
+ * @param players list of player display names participating in the run
+ */
+public record TimeLeaderboardEntryResponse(Long id, Integer week, Integer time, List<String> players) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScorePlayerRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScorePlayerRepository.java
@@ -1,0 +1,64 @@
+package com.opyruso.nwleaderboard.repository;
+
+import com.opyruso.nwleaderboard.entity.RunScorePlayer;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Repository exposing read operations for {@link RunScorePlayer} entities.
+ */
+@ApplicationScoped
+public class RunScorePlayerRepository implements PanacheRepository<RunScorePlayer> {
+
+    /**
+     * Retrieves the ordered mapping of run identifiers to participant names.
+     *
+     * @param runIds identifiers of the runs to fetch
+     * @return map keyed by run identifier with the ordered list of participant names
+     */
+    public Map<Long, List<String>> findPlayerNamesByRunIds(List<Long> runIds) {
+        if (runIds == null || runIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<RunScorePlayer> associations = find(
+                        "runScore.id in ?1 ORDER BY runScore.id ASC, player.playerName ASC",
+                        runIds)
+                .list();
+
+        LinkedHashMap<Long, List<String>> namesByRun = new LinkedHashMap<>();
+        for (RunScorePlayer association : associations) {
+            if (association == null || association.getRunScore() == null) {
+                continue;
+            }
+            Long runId = association.getRunScore().getId();
+            if (runId == null) {
+                continue;
+            }
+            String playerName = extractPlayerName(association);
+            if (playerName == null) {
+                continue;
+            }
+            namesByRun.computeIfAbsent(runId, ignored -> new java.util.ArrayList<>()).add(playerName);
+        }
+
+        namesByRun.replaceAll((id, names) -> List.copyOf(names));
+        return Collections.unmodifiableMap(namesByRun);
+    }
+
+    private String extractPlayerName(RunScorePlayer association) {
+        if (association.getPlayer() == null) {
+            return null;
+        }
+        String name = association.getPlayer().getPlayerName();
+        if (name == null) {
+            return null;
+        }
+        String trimmed = name.strip();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
@@ -1,0 +1,23 @@
+package com.opyruso.nwleaderboard.repository;
+
+import com.opyruso.nwleaderboard.entity.RunScore;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Repository exposing read operations for {@link RunScore} entities.
+ */
+@ApplicationScoped
+public class RunScoreRepository implements PanacheRepository<RunScore> {
+
+    /**
+     * Returns the list of {@link RunScore} entries for the requested dungeon ordered by score.
+     *
+     * @param dungeonId identifier of the dungeon
+     * @return ordered list of run scores for the dungeon
+     */
+    public List<RunScore> listByDungeonId(Long dungeonId) {
+        return find("dungeon.id = ?1 ORDER BY score DESC, week ASC, id ASC", dungeonId).list();
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
@@ -1,0 +1,23 @@
+package com.opyruso.nwleaderboard.repository;
+
+import com.opyruso.nwleaderboard.entity.RunTime;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Repository exposing read operations for {@link RunTime} entities.
+ */
+@ApplicationScoped
+public class RunTimeRepository implements PanacheRepository<RunTime> {
+
+    /**
+     * Returns the list of {@link RunTime} entries for the requested dungeon ordered by completion time.
+     *
+     * @param dungeonId identifier of the dungeon
+     * @return ordered list of run times for the dungeon
+     */
+    public List<RunTime> listByDungeonId(Long dungeonId) {
+        return find("dungeon.id = ?1 ORDER BY timeInSecond ASC, week ASC, id ASC", dungeonId).list();
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
@@ -1,0 +1,122 @@
+package com.opyruso.nwleaderboard.service;
+
+import com.opyruso.nwleaderboard.dto.ScoreLeaderboardEntryResponse;
+import com.opyruso.nwleaderboard.dto.TimeLeaderboardEntryResponse;
+import com.opyruso.nwleaderboard.entity.RunScore;
+import com.opyruso.nwleaderboard.entity.RunTime;
+import com.opyruso.nwleaderboard.repository.RunScorePlayerRepository;
+import com.opyruso.nwleaderboard.repository.RunScoreRepository;
+import com.opyruso.nwleaderboard.repository.RunTimePlayerRepository;
+import com.opyruso.nwleaderboard.repository.RunTimeRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Domain service responsible for assembling leaderboard responses.
+ */
+@ApplicationScoped
+public class LeaderboardService {
+
+    @Inject
+    RunScoreRepository runScoreRepository;
+
+    @Inject
+    RunScorePlayerRepository runScorePlayerRepository;
+
+    @Inject
+    RunTimeRepository runTimeRepository;
+
+    @Inject
+    RunTimePlayerRepository runTimePlayerRepository;
+
+    /**
+     * Retrieves the score leaderboard for the provided dungeon identifier.
+     *
+     * @param dungeonId identifier of the dungeon
+     * @return ordered list of score leaderboard entries
+     */
+    @Transactional(Transactional.TxType.SUPPORTS)
+    public List<ScoreLeaderboardEntryResponse> getScoreLeaderboard(Long dungeonId) {
+        if (dungeonId == null) {
+            return List.of();
+        }
+
+        List<RunScore> runs = runScoreRepository.listByDungeonId(dungeonId).stream()
+                .filter(Objects::nonNull)
+                .toList();
+        if (runs.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> runIds = runs.stream()
+                .map(RunScore::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<Long, List<String>> playersByRun = runScorePlayerRepository.findPlayerNamesByRunIds(runIds);
+
+        ArrayList<ScoreLeaderboardEntryResponse> responses = new ArrayList<>(runs.size());
+        for (RunScore run : runs) {
+            Long runId = run.getId();
+            if (runId == null) {
+                continue;
+            }
+            Integer score = run.getScore();
+            if (score == null) {
+                continue;
+            }
+            Integer week = run.getWeek();
+            List<String> players = playersByRun.getOrDefault(runId, List.of());
+            responses.add(new ScoreLeaderboardEntryResponse(runId, week, score, players));
+        }
+        return List.copyOf(responses);
+    }
+
+    /**
+     * Retrieves the time leaderboard for the provided dungeon identifier.
+     *
+     * @param dungeonId identifier of the dungeon
+     * @return ordered list of time leaderboard entries
+     */
+    @Transactional(Transactional.TxType.SUPPORTS)
+    public List<TimeLeaderboardEntryResponse> getTimeLeaderboard(Long dungeonId) {
+        if (dungeonId == null) {
+            return List.of();
+        }
+
+        List<RunTime> runs = runTimeRepository.listByDungeonId(dungeonId).stream()
+                .filter(Objects::nonNull)
+                .toList();
+        if (runs.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> runIds = runs.stream()
+                .map(RunTime::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<Long, List<String>> playersByRun = runTimePlayerRepository.findPlayerNamesByRunIds(runIds);
+
+        ArrayList<TimeLeaderboardEntryResponse> responses = new ArrayList<>(runs.size());
+        for (RunTime run : runs) {
+            Long runId = run.getId();
+            if (runId == null) {
+                continue;
+            }
+            Integer time = run.getTimeInSecond();
+            if (time == null) {
+                continue;
+            }
+            Integer week = run.getWeek();
+            List<String> players = playersByRun.getOrDefault(runId, List.of());
+            responses.add(new TimeLeaderboardEntryResponse(runId, week, time, players));
+        }
+        return List.copyOf(responses);
+    }
+}


### PR DESCRIPTION
## Summary
- add a REST resource that exposes score and time leaderboard endpoints requiring a dungeon id
- introduce a service plus repositories to collect run metadata and participant names
- define DTOs for score and time entries returned to the UI

## Testing
- `mvn -q package -DskipTests` *(fails: unable to reach Maven Central from container)*

------
https://chatgpt.com/codex/tasks/task_e_68d01536961c832ca4264ff2022010dc