### PR TITLE
feat: authenticate directly with IDP

### DIFF
--- a/nwleaderboard-ui/js/auth.js
+++ b/nwleaderboard-ui/js/auth.js
@@ -1,5 +1,14 @@
 const TOKEN_STORAGE_KEY = 'tokens';
 const TOKEN_EXPIRY_BUFFER = 30 * 1000;
+const AUTH_CONFIG = window.CONFIG || {};
+const AUTH_SERVER_URL = AUTH_CONFIG['auth-url'];
+const AUTH_REALM = AUTH_CONFIG['auth-realm'];
+const AUTH_CLIENT_ID = AUTH_CONFIG['auth-client-id'];
+const AUTH_CLIENT_SECRET = AUTH_CONFIG['auth-client-secret'];
+const TOKEN_ENDPOINT =
+  AUTH_SERVER_URL && AUTH_REALM
+    ? `${AUTH_SERVER_URL}/realms/${AUTH_REALM}/protocol/openid-connect/token`
+    : null;
 let refreshTimerId = null;
 let fetchInitialised = false;
 
@@ -24,13 +33,27 @@ function persistTokens(tokens, remember) {
 }
 
 export function storeTokens(tokens, remember) {
+  if (!tokens || !tokens.access_token) {
+    throw new Error('Cannot store empty tokens');
+  }
   const now = Date.now();
   const expiresInMs = tokens.expires_in ? tokens.expires_in * 1000 : 15 * 60 * 1000;
+  const refreshExpiresInMs =
+    typeof tokens.refresh_expires_in === 'number' && tokens.refresh_expires_in > 0
+      ? tokens.refresh_expires_in * 1000
+      : null;
   const withExpiry = {
     ...tokens,
     expires_at: tokens.expires_at || now + expiresInMs,
+    refresh_expires_at: tokens.refresh_expires_at || (refreshExpiresInMs ? now + refreshExpiresInMs : null),
     stored_at: now,
+    remember: !!remember,
   };
+  if (remember && tokens.refresh_token) {
+    withExpiry.offline_token = tokens.offline_token || tokens.refresh_token;
+  } else if (!remember && withExpiry.offline_token) {
+    delete withExpiry.offline_token;
+  }
   persistTokens(withExpiry, remember);
   startTokenRefresh();
 }
@@ -68,14 +91,18 @@ function scheduleRefresh() {
   if (!tokens || !tokens.expires_at) {
     return;
   }
-  const msUntilExpiry = tokens.expires_at - Date.now();
-  if (msUntilExpiry <= 0) {
+  if (tokens.refresh_expires_at && tokens.refresh_expires_at <= Date.now()) {
     window.dispatchEvent(new Event('unauthenticated'));
+    return;
+  }
+  const msUntilExpiry = tokens.expires_at - Date.now();
+  if (msUntilExpiry <= TOKEN_EXPIRY_BUFFER) {
+    attemptTokenRefresh();
     return;
   }
   const delay = Math.max(msUntilExpiry - TOKEN_EXPIRY_BUFFER, 1000);
   refreshTimerId = window.setTimeout(() => {
-    window.dispatchEvent(new Event('unauthenticated'));
+    attemptTokenRefresh();
   }, delay);
 }
 
@@ -97,9 +124,110 @@ export function getStoredTokens() {
 export function isAuthenticated() {
   const tokens = readStoredTokens();
   if (!tokens || !tokens.access_token) return false;
-  if (tokens.expires_at && tokens.expires_at < Date.now()) {
-    clearTokens();
+  return true;
+}
+
+function buildFormData(params) {
+  const form = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      form.set(key, value);
+    }
+  });
+  return form.toString();
+}
+
+async function requestToken(formData) {
+  if (!TOKEN_ENDPOINT) {
+    throw new Error('Authentication server not configured');
+  }
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: formData,
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    payload = null;
+  }
+  if (!response.ok) {
+    const error = new Error('Authentication request failed');
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+  if (!payload || !payload.access_token) {
+    throw new Error('Authentication server returned an invalid payload');
+  }
+  return payload;
+}
+
+async function attemptTokenRefresh() {
+  try {
+    const refreshed = await refreshTokens();
+    if (!refreshed) {
+      window.dispatchEvent(new Event('unauthenticated'));
+    }
+  } catch (error) {
+    console.warn('Token refresh failed', error);
+    window.dispatchEvent(new Event('unauthenticated'));
+  }
+}
+
+export async function loginWithPassword(username, password, remember) {
+  const params = {
+    grant_type: 'password',
+    client_id: AUTH_CLIENT_ID,
+    username,
+    password,
+    scope: remember ? 'openid offline_access' : 'openid',
+  };
+  if (AUTH_CLIENT_SECRET) {
+    params.client_secret = AUTH_CLIENT_SECRET;
+  }
+  const formData = buildFormData(params);
+  return requestToken(formData);
+}
+
+export async function refreshTokens() {
+  const tokens = readStoredTokens();
+  if (!tokens) {
     return false;
   }
-  return true;
+  if (tokens.refresh_expires_at && tokens.refresh_expires_at <= Date.now()) {
+    return false;
+  }
+  const refreshToken = tokens.refresh_token || tokens.offline_token;
+  if (!refreshToken) {
+    return false;
+  }
+  const params = {
+    grant_type: 'refresh_token',
+    client_id: AUTH_CLIENT_ID,
+    refresh_token: refreshToken,
+  };
+  if (AUTH_CLIENT_SECRET) {
+    params.client_secret = AUTH_CLIENT_SECRET;
+  }
+  const formData = buildFormData(params);
+  try {
+    const payload = await requestToken(formData);
+    const remember = !!tokens.remember;
+    const merged = {
+      ...tokens,
+      ...payload,
+    };
+    if (tokens.offline_token) {
+      merged.offline_token = payload.refresh_token || tokens.offline_token;
+    }
+    storeTokens(merged, remember);
+    return true;
+  } catch (error) {
+    console.warn('Unable to refresh tokens', error);
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- authenticate directly with the identity provider and store refresh/offline tokens depending on the remember me option
- automatically refresh access tokens before expiry using stored refresh or offline tokens
- update the login form to rely on the new IDP authentication flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d038aa7d68832ca7088a3228c6bf8a