### PR TITLE
Add leaderboard endpoints for score and time

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
@@ -1,0 +1,49 @@
+package com.opyruso.nwleaderboard;
+
+import com.opyruso.nwleaderboard.dto.ApiMessageResponse;
+import com.opyruso.nwleaderboard.dto.LeaderboardEntryResponse;
+import com.opyruso.nwleaderboard.service.LeaderboardService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.util.List;
+
+/**
+ * REST resource exposing leaderboard entries grouped by dungeon and mode.
+ */
+@Path("/leaderboard")
+@Produces(MediaType.APPLICATION_JSON)
+public class LeaderboardResource {
+
+    @Inject
+    LeaderboardService leaderboardService;
+
+    @GET
+    @Path("/score")
+    public Response getScore(@QueryParam("dungeonId") Long dungeonId, @QueryParam("limit") Integer limit) {
+        if (dungeonId == null) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
+                    .build();
+        }
+        List<LeaderboardEntryResponse> entries = leaderboardService.getScoreEntries(dungeonId, limit);
+        return Response.ok(entries).build();
+    }
+
+    @GET
+    @Path("/time")
+    public Response getTime(@QueryParam("dungeonId") Long dungeonId, @QueryParam("limit") Integer limit) {
+        if (dungeonId == null) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
+                    .build();
+        }
+        List<LeaderboardEntryResponse> entries = leaderboardService.getTimeEntries(dungeonId, limit);
+        return Response.ok(entries).build();
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardEntryResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardEntryResponse.java
@@ -1,0 +1,19 @@
+package com.opyruso.nwleaderboard.dto;
+
+import java.util.List;
+
+/**
+ * Response payload representing a single leaderboard entry.
+ */
+public record LeaderboardEntryResponse(
+        Long entryId,
+        Integer week,
+        Integer value,
+        Integer score,
+        Integer time,
+        List<String> players) {
+
+    public LeaderboardEntryResponse {
+        players = players == null ? List.of() : List.copyOf(players);
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScorePlayerRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScorePlayerRepository.java
@@ -3,10 +3,30 @@ package com.opyruso.nwleaderboard.repository;
 import com.opyruso.nwleaderboard.entity.RunScorePlayer;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
 
 /**
  * Repository for {@link RunScorePlayer} association entities.
  */
 @ApplicationScoped
 public class RunScorePlayerRepository implements PanacheRepository<RunScorePlayer> {
+
+    /**
+     * Loads the player associations for the provided runs including the related player entity.
+     *
+     * @param runIds identifiers of the runs
+     * @return association list ordered by run identifier and player name
+     */
+    public List<RunScorePlayer> listWithPlayersByRunIds(List<Long> runIds) {
+        if (runIds == null || runIds.isEmpty()) {
+            return List.of();
+        }
+        return find(
+                        "SELECT rsp FROM RunScorePlayer rsp "
+                                + "JOIN FETCH rsp.player "
+                                + "WHERE rsp.runScore.id IN ?1 "
+                                + "ORDER BY rsp.runScore.id ASC, LOWER(rsp.player.playerName) ASC",
+                        runIds)
+                .list();
+    }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
@@ -2,11 +2,29 @@ package com.opyruso.nwleaderboard.repository;
 
 import com.opyruso.nwleaderboard.entity.RunScore;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.panache.common.Page;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
 
 /**
  * Repository for persisting {@link RunScore} entities extracted from contributor uploads.
  */
 @ApplicationScoped
 public class RunScoreRepository implements PanacheRepository<RunScore> {
+
+    /**
+     * Returns the highest score runs recorded for the provided dungeon.
+     *
+     * @param dungeonId identifier of the dungeon
+     * @param limit maximum number of runs to return
+     * @return list of runs ordered by score descending and week descending
+     */
+    public List<RunScore> listTopByDungeon(Long dungeonId, int limit) {
+        if (dungeonId == null || limit <= 0) {
+            return List.of();
+        }
+        return find("dungeon.id = ?1 ORDER BY score DESC, week DESC, id ASC", dungeonId)
+                .page(Page.ofSize(limit))
+                .list();
+    }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimePlayerRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimePlayerRepository.java
@@ -3,10 +3,30 @@ package com.opyruso.nwleaderboard.repository;
 import com.opyruso.nwleaderboard.entity.RunTimePlayer;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
 
 /**
  * Repository for {@link RunTimePlayer} association entities.
  */
 @ApplicationScoped
 public class RunTimePlayerRepository implements PanacheRepository<RunTimePlayer> {
+
+    /**
+     * Loads the player associations for the provided time runs including the related player entity.
+     *
+     * @param runIds identifiers of the runs
+     * @return association list ordered by run identifier and player name
+     */
+    public List<RunTimePlayer> listWithPlayersByRunIds(List<Long> runIds) {
+        if (runIds == null || runIds.isEmpty()) {
+            return List.of();
+        }
+        return find(
+                        "SELECT rtp FROM RunTimePlayer rtp "
+                                + "JOIN FETCH rtp.player "
+                                + "WHERE rtp.runTime.id IN ?1 "
+                                + "ORDER BY rtp.runTime.id ASC, LOWER(rtp.player.playerName) ASC",
+                        runIds)
+                .list();
+    }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
@@ -2,11 +2,29 @@ package com.opyruso.nwleaderboard.repository;
 
 import com.opyruso.nwleaderboard.entity.RunTime;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.panache.common.Page;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
 
 /**
  * Repository for {@link RunTime} entities extracted from contributor uploads.
  */
 @ApplicationScoped
 public class RunTimeRepository implements PanacheRepository<RunTime> {
+
+    /**
+     * Returns the fastest runs recorded for the provided dungeon.
+     *
+     * @param dungeonId identifier of the dungeon
+     * @param limit maximum number of runs to return
+     * @return list of runs ordered by duration ascending and week descending
+     */
+    public List<RunTime> listTopByDungeon(Long dungeonId, int limit) {
+        if (dungeonId == null || limit <= 0) {
+            return List.of();
+        }
+        return find("dungeon.id = ?1 ORDER BY timeInSecond ASC, week DESC, id ASC", dungeonId)
+                .page(Page.ofSize(limit))
+                .list();
+    }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
@@ -1,0 +1,184 @@
+package com.opyruso.nwleaderboard.service;
+
+import com.opyruso.nwleaderboard.dto.LeaderboardEntryResponse;
+import com.opyruso.nwleaderboard.entity.RunScore;
+import com.opyruso.nwleaderboard.entity.RunTime;
+import com.opyruso.nwleaderboard.repository.RunScorePlayerRepository;
+import com.opyruso.nwleaderboard.repository.RunScoreRepository;
+import com.opyruso.nwleaderboard.repository.RunTimePlayerRepository;
+import com.opyruso.nwleaderboard.repository.RunTimeRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Provides read access to leaderboard entries for both score and time modes.
+ */
+@ApplicationScoped
+public class LeaderboardService {
+
+    private static final int DEFAULT_LIMIT = 50;
+    private static final int MAX_LIMIT = 100;
+
+    @Inject
+    RunScoreRepository runScoreRepository;
+
+    @Inject
+    RunScorePlayerRepository runScorePlayerRepository;
+
+    @Inject
+    RunTimeRepository runTimeRepository;
+
+    @Inject
+    RunTimePlayerRepository runTimePlayerRepository;
+
+    @Transactional(Transactional.TxType.SUPPORTS)
+    public List<LeaderboardEntryResponse> getScoreEntries(Long dungeonId, Integer limit) {
+        if (dungeonId == null) {
+            return List.of();
+        }
+        int safeLimit = sanitiseLimit(limit);
+        List<RunScore> runs = runScoreRepository.listTopByDungeon(dungeonId, safeLimit);
+        if (runs.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, List<String>> playersByRun = loadPlayersForScoreRuns(runs);
+        List<LeaderboardEntryResponse> responses = new ArrayList<>(runs.size());
+        for (RunScore run : runs) {
+            Long runId = run.getId();
+            Integer score = run.getScore();
+            responses.add(new LeaderboardEntryResponse(
+                    runId,
+                    run.getWeek(),
+                    score,
+                    score,
+                    null,
+                    playersByRun.getOrDefault(runId, List.of())));
+        }
+        return List.copyOf(responses);
+    }
+
+    @Transactional(Transactional.TxType.SUPPORTS)
+    public List<LeaderboardEntryResponse> getTimeEntries(Long dungeonId, Integer limit) {
+        if (dungeonId == null) {
+            return List.of();
+        }
+        int safeLimit = sanitiseLimit(limit);
+        List<RunTime> runs = runTimeRepository.listTopByDungeon(dungeonId, safeLimit);
+        if (runs.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, List<String>> playersByRun = loadPlayersForTimeRuns(runs);
+        List<LeaderboardEntryResponse> responses = new ArrayList<>(runs.size());
+        for (RunTime run : runs) {
+            Long runId = run.getId();
+            Integer time = run.getTimeInSecond();
+            responses.add(new LeaderboardEntryResponse(
+                    runId,
+                    run.getWeek(),
+                    time,
+                    null,
+                    time,
+                    playersByRun.getOrDefault(runId, List.of())));
+        }
+        return List.copyOf(responses);
+    }
+
+    private Map<Long, List<String>> loadPlayersForScoreRuns(List<RunScore> runs) {
+        List<Long> runIds = runs.stream()
+                .map(RunScore::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (runIds.isEmpty()) {
+            return Map.of();
+        }
+        List<PlayerAssignment> assignments = runScorePlayerRepository.listWithPlayersByRunIds(runIds).stream()
+                .map(association -> new PlayerAssignment(
+                        association.getRunScore() != null ? association.getRunScore().getId() : null,
+                        association.getPlayer() != null ? association.getPlayer().getPlayerName() : null))
+                .toList();
+        return organisePlayers(runIds, assignments);
+    }
+
+    private Map<Long, List<String>> loadPlayersForTimeRuns(List<RunTime> runs) {
+        List<Long> runIds = runs.stream()
+                .map(RunTime::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (runIds.isEmpty()) {
+            return Map.of();
+        }
+        List<PlayerAssignment> assignments = runTimePlayerRepository.listWithPlayersByRunIds(runIds).stream()
+                .map(association -> new PlayerAssignment(
+                        association.getRunTime() != null ? association.getRunTime().getId() : null,
+                        association.getPlayer() != null ? association.getPlayer().getPlayerName() : null))
+                .toList();
+        return organisePlayers(runIds, assignments);
+    }
+
+    private Map<Long, List<String>> organisePlayers(List<Long> runIds, List<PlayerAssignment> assignments) {
+        if (runIds.isEmpty()) {
+            return Map.of();
+        }
+        LinkedHashMap<Long, List<String>> playersByRun = runIds.stream()
+                .collect(Collectors.toMap(id -> id, id -> new ArrayList<>(), (left, right) -> left, LinkedHashMap::new));
+        for (PlayerAssignment assignment : assignments) {
+            if (assignment == null) {
+                continue;
+            }
+            Long runId = assignment.runId();
+            if (runId == null) {
+                continue;
+            }
+            List<String> bucket = playersByRun.get(runId);
+            if (bucket == null) {
+                continue;
+            }
+            String name = assignment.playerName();
+            if (name != null) {
+                bucket.add(name);
+            }
+        }
+        playersByRun.replaceAll((runId, names) -> normalisePlayerNames(names));
+        return Collections.unmodifiableMap(playersByRun);
+    }
+
+    private List<String> normalisePlayerNames(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return List.of();
+        }
+        LinkedHashMap<String, String> unique = new LinkedHashMap<>();
+        for (String name : names) {
+            if (name == null) {
+                continue;
+            }
+            String trimmed = name.strip();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            String key = trimmed.toLowerCase(Locale.ROOT);
+            unique.putIfAbsent(key, trimmed);
+        }
+        return List.copyOf(unique.values());
+    }
+
+    private int sanitiseLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.min(limit, MAX_LIMIT);
+    }
+
+    private record PlayerAssignment(Long runId, String playerName) {
+    }
+}


### PR DESCRIPTION
## Summary
- expose `/leaderboard/score` and `/leaderboard/time` endpoints backed by a new service layer
- return immutable leaderboard entry DTOs including player names for the requested dungeon
- extend score/time repositories with helpers to fetch the top runs and preload associated players

## Testing
- `mvn -DskipTests package` *(fails: unable to reach Maven Central from the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d04a669190832c83e6119c5f6e9c9a