### PR TITLE
feat: preprocess contributor uploads before OCR

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributionFieldExtractionDto.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributionFieldExtractionDto.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Describes the raw OCR output and associated crop for a specific region of the contributor screenshot.
+ * Describes the raw OCR output and associated preprocessed crop for a specific region of the contributor screenshot.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ContributionFieldExtractionDto(


### PR DESCRIPTION
## Summary
- invert and contrast contributor screenshots before running OCR
- run OCR on the prepared image and expose the preprocessed crops in API responses
- document that returned crops represent the preprocessed regions

## Testing
- mvn -B test *(fails: missing dependency versions for Quarkus artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68d05c02dcdc832c83deed83f2a5df06