### PR TITLE
Add contributor weekly run statistics view

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/ContributorResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/ContributorResource.java
@@ -3,17 +3,20 @@ package com.opyruso.nwleaderboard;
 import com.opyruso.nwleaderboard.dto.ApiMessageResponse;
 import com.opyruso.nwleaderboard.dto.ContributionExtractionResponseDto;
 import com.opyruso.nwleaderboard.dto.ContributionRunDto;
+import com.opyruso.nwleaderboard.dto.ContributorWeeklyRunsResponse;
 import com.opyruso.nwleaderboard.dto.UpdateDungeonHighlightsRequest;
 import com.opyruso.nwleaderboard.service.ContributorExtractionService;
 import com.opyruso.nwleaderboard.service.ContributorExtractionService.ContributorRequestException;
 import com.opyruso.nwleaderboard.service.ContributorSubmissionService;
 import com.opyruso.nwleaderboard.service.ContributorSubmissionService.ContributorSubmissionException;
+import com.opyruso.nwleaderboard.service.ContributorStatisticsService;
 import com.opyruso.nwleaderboard.service.DungeonService;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -52,6 +55,9 @@ public class ContributorResource {
 
     @Inject
     DungeonService dungeonService;
+
+    @Inject
+    ContributorStatisticsService statisticsService;
 
     @POST
     @Path("/extract")
@@ -124,6 +130,25 @@ public class ContributorResource {
             LOG.error("Unable to update highlighted dungeons", e);
             return Response.status(Status.BAD_GATEWAY)
                     .entity(new ApiMessageResponse("Unable to update dungeon highlights", null))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/runs/weekly")
+    public Response listRunsByWeek() {
+        if (!hasContributorRole()) {
+            return Response.status(Status.FORBIDDEN)
+                    .entity(new ApiMessageResponse("Contributor role required", null))
+                    .build();
+        }
+        try {
+            List<ContributorWeeklyRunsResponse> summaries = statisticsService.listRunsByWeek();
+            return Response.ok(summaries).build();
+        } catch (Exception e) {
+            LOG.error("Unable to load contributor run statistics", e);
+            return Response.status(Status.BAD_GATEWAY)
+                    .entity(new ApiMessageResponse("Unable to load run statistics", null))
                     .build();
         }
     }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorWeeklyRunsResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorWeeklyRunsResponse.java
@@ -1,0 +1,11 @@
+package com.opyruso.nwleaderboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Summary of the number of runs recorded for a specific week.
+ */
+public record ContributorWeeklyRunsResponse(
+        @JsonProperty("week") Integer week,
+        @JsonProperty("score_runs") Long scoreRuns,
+        @JsonProperty("time_runs") Long timeRuns) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
@@ -4,7 +4,10 @@ import com.opyruso.nwleaderboard.entity.RunTime;
 import io.quarkus.hibernate.orm.panache.PanacheRepository;
 import io.quarkus.panache.common.Page;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.NoResultException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Repository for {@link RunTime} entities extracted from contributor uploads.
@@ -71,5 +74,44 @@ public class RunTimeRepository implements PanacheRepository<RunTime> {
                                 + "ORDER BY run.timeInSecond ASC, run.week DESC, run.id ASC",
                         playerId)
                 .list();
+    }
+
+    /** Returns the highest recorded week for time runs or {@code null} when none exist. */
+    public Integer findHighestWeek() {
+        try {
+            return getEntityManager()
+                    .createQuery("SELECT MAX(run.week) FROM RunTime run", Integer.class)
+                    .getSingleResult();
+        } catch (NoResultException ignored) {
+            return null;
+        }
+    }
+
+    /** Returns a map containing the number of time runs grouped by week. */
+    public Map<Integer, Long> countRunsGroupedByWeek() {
+        List<Object[]> rows = getEntityManager()
+                .createQuery("SELECT run.week, COUNT(run) FROM RunTime run GROUP BY run.week", Object[].class)
+                .getResultList();
+        Map<Integer, Long> result = new HashMap<>();
+        for (Object[] row : rows) {
+            if (row == null || row.length < 2) {
+                continue;
+            }
+            Object weekValue = row[0];
+            Object countValue = row[1];
+            if (!(weekValue instanceof Integer) || countValue == null) {
+                continue;
+            }
+            long count;
+            if (countValue instanceof Long longValue) {
+                count = longValue;
+            } else if (countValue instanceof Number number) {
+                count = number.longValue();
+            } else {
+                continue;
+            }
+            result.put((Integer) weekValue, count);
+        }
+        return result;
     }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorStatisticsService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorStatisticsService.java
@@ -1,0 +1,53 @@
+package com.opyruso.nwleaderboard.service;
+
+import com.opyruso.nwleaderboard.dto.ContributorWeeklyRunsResponse;
+import com.opyruso.nwleaderboard.repository.RunScoreRepository;
+import com.opyruso.nwleaderboard.repository.RunTimeRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides aggregated statistics about runs submitted by contributors.
+ */
+@ApplicationScoped
+public class ContributorStatisticsService {
+
+    @Inject
+    RunScoreRepository runScoreRepository;
+
+    @Inject
+    RunTimeRepository runTimeRepository;
+
+    /**
+     * Returns the number of score and time runs recorded for each week.
+     *
+     * @return list of weekly summaries sorted by week in descending order
+     */
+    public List<ContributorWeeklyRunsResponse> listRunsByWeek() {
+        int highestWeek = Math.max(
+                safeWeek(runScoreRepository.findHighestWeek()), safeWeek(runTimeRepository.findHighestWeek()));
+
+        if (highestWeek <= 0) {
+            return List.of();
+        }
+
+        Map<Integer, Long> scoreRuns = new HashMap<>(runScoreRepository.countRunsGroupedByWeek());
+        Map<Integer, Long> timeRuns = new HashMap<>(runTimeRepository.countRunsGroupedByWeek());
+
+        List<ContributorWeeklyRunsResponse> summaries = new ArrayList<>(highestWeek);
+        for (int week = highestWeek; week >= 1; week--) {
+            long scoreCount = scoreRuns.getOrDefault(week, 0L);
+            long timeCount = timeRuns.getOrDefault(week, 0L);
+            summaries.add(new ContributorWeeklyRunsResponse(week, scoreCount, timeCount));
+        }
+        return summaries;
+    }
+
+    private int safeWeek(Integer value) {
+        return value != null && value > 0 ? value : 0;
+    }
+}

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -258,6 +258,72 @@ body[data-theme='light'] .form-field-floating input:not(:placeholder-shown) + sp
   display: flex;
 }
 
+.contribute-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contribute-stats-table-container {
+  background: var(--surface-dark);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-elevated);
+  padding: 1.5rem;
+  backdrop-filter: blur(18px);
+  overflow-x: auto;
+}
+
+body[data-theme='light'] .contribute-stats-table-container {
+  background: var(--surface-light);
+  box-shadow: none;
+}
+
+.contribute-stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 320px;
+  font-variant-numeric: tabular-nums;
+}
+
+.contribute-stats-table th,
+.contribute-stats-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-dark);
+  text-align: left;
+}
+
+body[data-theme='light'] .contribute-stats-table th,
+body[data-theme='light'] .contribute-stats-table td {
+  border-bottom-color: var(--border-light);
+}
+
+.contribute-stats-table thead th {
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.contribute-stats-table tbody tr:last-child th,
+.contribute-stats-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.contribute-stats-table tbody tr:hover {
+  background: rgba(124, 92, 255, 0.08);
+}
+
+body[data-theme='light'] .contribute-stats-table tbody tr:hover {
+  background: rgba(124, 92, 255, 0.14);
+}
+
+.contribute-stats-table th[scope='col']:nth-child(2),
+.contribute-stats-table th[scope='col']:nth-child(3),
+.contribute-stats-table td:nth-child(2),
+.contribute-stats-table td:nth-child(3) {
+  text-align: right;
+}
+
 .contribute-dungeon-checkbox {
   display: flex;
   align-items: flex-start;

--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -11,6 +11,7 @@ import Password from './pages/Password.js';
 import Contribute from './pages/Contribute.js';
 import ContributeDungeons from './pages/ContributeDungeons.js';
 import ContributeImport from './pages/ContributeImport.js';
+import ContributeStats from './pages/ContributeStats.js';
 import Player from './pages/Player.js';
 import VersionChecker from './VersionChecker.js';
 import {
@@ -107,6 +108,7 @@ export default function App() {
           >
             <Route index element={<ContributeDungeons />} />
             <Route path="import" element={<ContributeImport />} />
+            <Route path="stats" element={<ContributeStats />} />
             <Route path="*" element={<Navigate to="." replace />} />
           </Route>
           <Route path="/player/:playerId?" element={<Player />} />

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -38,8 +38,17 @@ const en = {
   contributeMenuLabel: 'Contributor sections',
   contributeMenuDungeons: 'Dungeons',
   contributeMenuImport: 'Import',
+  contributeMenuStats: 'Weekly runs',
   contributeDungeonsDescription:
     'Choose which dungeons are highlighted on the home page. Only selected dungeons will appear in the highlights.',
+  contributeStatsDescription:
+    'Review how many score and time runs have been submitted each week.',
+  contributeStatsLoading: 'Loading run statistics…',
+  contributeStatsError: 'Unable to load run statistics.',
+  contributeStatsEmpty: 'No runs recorded yet.',
+  contributeStatsWeek: 'Week',
+  contributeStatsScoreRuns: 'Score runs',
+  contributeStatsTimeRuns: 'Time runs',
   contributeHighlightsSave: 'Save selection',
   contributeHighlightsSaving: 'Saving…',
   contributeHighlightsSaved: 'Highlighted dungeons updated.',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -39,8 +39,17 @@ const fr = {
   contributeMenuLabel: 'Sections contributeur',
   contributeMenuDungeons: 'Donjons',
   contributeMenuImport: 'Importer',
+  contributeMenuStats: 'Statistiques',
   contributeDungeonsDescription:
     'Sélectionnez les donjons mis en avant sur la page d’accueil. Seuls les donjons cochés apparaîtront dans les faits marquants.',
+  contributeStatsDescription:
+    'Consultez le nombre de runs score et temps enregistrés chaque semaine.',
+  contributeStatsLoading: 'Chargement des statistiques…',
+  contributeStatsError: 'Impossible de charger les statistiques des runs.',
+  contributeStatsEmpty: 'Aucun run enregistré pour le moment.',
+  contributeStatsWeek: 'Semaine',
+  contributeStatsScoreRuns: 'Runs score',
+  contributeStatsTimeRuns: 'Runs temps',
   contributeHighlightsSave: 'Enregistrer la sélection',
   contributeHighlightsSaving: 'Enregistrement…',
   contributeHighlightsSaved: 'Faits marquants mis à jour.',

--- a/nwleaderboard-ui/js/pages/Contribute.js
+++ b/nwleaderboard-ui/js/pages/Contribute.js
@@ -30,6 +30,14 @@ export default function Contribute() {
         >
           {t.contributeMenuImport || t.contribute}
         </NavLink>
+        <NavLink
+          to="/contribute/stats"
+          className={({ isActive }) =>
+            isActive ? 'page-submenu-link active' : 'page-submenu-link'
+          }
+        >
+          {t.contributeMenuStats || 'Weekly runs'}
+        </NavLink>
       </PageSubmenu>
       <Outlet />
     </main>

--- a/nwleaderboard-ui/js/pages/ContributeStats.js
+++ b/nwleaderboard-ui/js/pages/ContributeStats.js
@@ -1,0 +1,119 @@
+import { LangContext } from '../i18n.js';
+
+const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
+
+export default function ContributeStats() {
+  const { t } = React.useContext(LangContext);
+  const [stats, setStats] = React.useState([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    let active = true;
+    const controller = new AbortController();
+    setLoading(true);
+    setError('');
+
+    fetch(`${API_BASE_URL}/contributor/runs/weekly`, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          return response
+            .json()
+            .catch(() => null)
+            .then((data) => {
+              const message = data && typeof data.message === 'string' ? data.message : '';
+              throw new Error(message || `Failed to load statistics: ${response.status}`);
+            });
+        }
+        return response.json();
+      })
+      .then((data) => {
+        if (!active) {
+          return;
+        }
+        if (!Array.isArray(data)) {
+          setStats([]);
+          return;
+        }
+        setStats(
+          data
+            .map((entry) => {
+              const weekValue =
+                entry && entry.week !== undefined && entry.week !== null
+                  ? Number.parseInt(entry.week, 10)
+                  : null;
+              const scoreValue =
+                entry && entry.score_runs !== undefined && entry.score_runs !== null
+                  ? Number(entry.score_runs)
+                  : 0;
+              const timeValue =
+                entry && entry.time_runs !== undefined && entry.time_runs !== null
+                  ? Number(entry.time_runs)
+                  : 0;
+              return {
+                week: Number.isFinite(weekValue) ? weekValue : null,
+                scoreRuns: Number.isFinite(scoreValue) ? scoreValue : 0,
+                timeRuns: Number.isFinite(timeValue) ? timeValue : 0,
+              };
+            })
+            .filter((entry) => entry.week !== null)
+        );
+      })
+      .catch((fetchError) => {
+        if (!active || fetchError.name === 'AbortError') {
+          return;
+        }
+        console.error('Unable to load contributor statistics', fetchError);
+        setError(fetchError && fetchError.message ? fetchError.message : t.contributeStatsError);
+        setStats([]);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [t]);
+
+  return (
+    <section className="contribute-stats">
+      <p className="page-description">{t.contributeStatsDescription}</p>
+      <div className="contribute-stats-table-container" aria-live="polite">
+        {loading ? <p className="form-hint">{t.contributeStatsLoading}</p> : null}
+        {error ? (
+          <p className="form-message error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        {!loading && !error ? (
+          stats.length === 0 ? (
+            <p className="form-hint">{t.contributeStatsEmpty}</p>
+          ) : (
+            <table className="contribute-stats-table">
+              <thead>
+                <tr>
+                  <th scope="col">{t.contributeStatsWeek}</th>
+                  <th scope="col">{t.contributeStatsScoreRuns}</th>
+                  <th scope="col">{t.contributeStatsTimeRuns}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.map((entry) => (
+                  <tr key={entry.week}>
+                    <th scope="row">{entry.week}</th>
+                    <td>{entry.scoreRuns}</td>
+                    <td>{entry.timeRuns}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
+        ) : null}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add repository helpers, DTO, and service to aggregate weekly score and time run counts for contributors
- expose a secured `/contributor/runs/weekly` endpoint returning the aggregated data
- add a contributor stats page with navigation, styling, and translations to display the weekly run table

## Testing
- mvn -f nwleaderboard-api/pom.xml test *(fails: dependency versions missing in this environment)*
- npm --prefix nwleaderboard-ui run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b267dc4c832c9ca9c8f82d7c37bf