### PR TITLE
Improve OCR row scanning with vertical offsets

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorExtractionService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorExtractionService.java
@@ -799,7 +799,7 @@ public class ContributorExtractionService {
             if (currentOffset >= maxOffset) {
                 break;
             }
-            int nextOffset = Math.min(maxOffset, currentOffset + 2);
+            int nextOffset = Math.min(maxOffset, currentOffset + 4);
             if (nextOffset == currentOffset) {
                 break;
             }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorExtractionService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorExtractionService.java
@@ -751,49 +751,144 @@ public class ContributorExtractionService {
         Map<String, Player> knownPlayersByName = indexPlayersByName(knownPlayers);
         int slotCount = clampPlayerSlotCount(expectedPlayerCount);
 
-        RowsExtractionAttempt bestAttempt = null;
-        double bestAverage = Double.NEGATIVE_INFINITY;
+        OffsetBounds bounds = computeOffsetBounds(originalImage, slotCount, RUNS_PER_IMAGE);
+        int allowedMin = bounds.minOffset();
+        int allowedMax = bounds.maxOffset();
+        int minOffset = Math.max(allowedMin, -10);
+        int maxOffset = Math.min(allowedMax, 135);
+        if (maxOffset < minOffset) {
+            if (allowedMin > 135) {
+                minOffset = allowedMin;
+                maxOffset = allowedMin;
+            } else if (allowedMax < -10) {
+                minOffset = allowedMax;
+                maxOffset = allowedMax;
+            } else {
+                int preferred = 0;
+                if (preferred < allowedMin) {
+                    preferred = allowedMin;
+                }
+                if (preferred > allowedMax) {
+                    preferred = allowedMax;
+                }
+                minOffset = preferred;
+                maxOffset = preferred;
+            }
+        }
 
-        int baseOffset = -10;
+        int currentOffset = minOffset;
+        int bestOffset = currentOffset;
+        double bestAverage = Double.NEGATIVE_INFINITY;
+        ContributionRunExtractionDto bestFirstRow = null;
+        boolean attempted = false;
+
         while (true) {
+            attempted = true;
             RowsExtractionAttempt attempt = extractRowsForOffset(originalImage, preparedImage, declaredMode, slotCount,
-                    knownPlayers, knownPlayersByName, baseOffset);
+                    knownPlayers, knownPlayersByName, currentOffset, 0, 1);
             double attemptAverage = attempt.averageConfidence();
-            if (attemptAverage > bestAverage) {
+            List<ContributionRunExtractionDto> attemptRows = attempt.rows();
+            if (!attemptRows.isEmpty() && (attemptAverage > bestAverage || bestFirstRow == null)) {
                 bestAverage = attemptAverage;
-                bestAttempt = attempt;
+                bestOffset = currentOffset;
+                bestFirstRow = attemptRows.get(0);
             }
             if (attemptAverage >= 95.0d) {
                 break;
             }
-            if (baseOffset >= 135) {
+            if (currentOffset >= maxOffset) {
                 break;
             }
-            int nextOffset = baseOffset + 2;
-            if (nextOffset > 135) {
-                nextOffset = 135;
-            }
-            if (nextOffset == baseOffset) {
+            int nextOffset = Math.min(maxOffset, currentOffset + 2);
+            if (nextOffset == currentOffset) {
                 break;
             }
-            baseOffset = nextOffset;
+            currentOffset = nextOffset;
         }
 
-        return bestAttempt != null ? bestAttempt.rows() : List.of();
+        if (!attempted) {
+            RowsExtractionAttempt attempt = extractRowsForOffset(originalImage, preparedImage, declaredMode, slotCount,
+                    knownPlayers, knownPlayersByName, bestOffset, 0, RUNS_PER_IMAGE);
+            return attempt.rows();
+        }
+
+        List<ContributionRunExtractionDto> rows = new ArrayList<>(RUNS_PER_IMAGE);
+        if (bestFirstRow != null) {
+            rows.add(bestFirstRow);
+        }
+
+        int startRowIndex = rows.isEmpty() ? 0 : 1;
+        int remainingRows = RUNS_PER_IMAGE - startRowIndex;
+        if (remainingRows > 0) {
+            RowsExtractionAttempt remainder = extractRowsForOffset(originalImage, preparedImage, declaredMode, slotCount,
+                    knownPlayers, knownPlayersByName, bestOffset, startRowIndex, remainingRows);
+            rows.addAll(remainder.rows());
+        }
+
+        if (rows.isEmpty()) {
+            RowsExtractionAttempt fallback = extractRowsForOffset(originalImage, preparedImage, declaredMode, slotCount,
+                    knownPlayers, knownPlayersByName, bestOffset, 0, RUNS_PER_IMAGE);
+            rows.addAll(fallback.rows());
+        }
+
+        return rows;
+    }
+
+    private OffsetBounds computeOffsetBounds(BufferedImage image, int slotCount, int rowsToConsider) {
+        int height = image != null && image.getHeight() > 0 ? image.getHeight() : EXPECTED_HEIGHT;
+        int effectiveRows = Math.min(Math.max(rowsToConsider, 0), RUNS_PER_IMAGE);
+        if (effectiveRows <= 0) {
+            return new OffsetBounds(-10, 135);
+        }
+
+        int minOffset = Integer.MIN_VALUE;
+        int maxOffset = Integer.MAX_VALUE;
+        int effectiveSlots = Math.min(Math.max(slotCount, 0), MAX_PLAYER_SLOTS);
+
+        for (int rowIndex = 0; rowIndex < effectiveRows; rowIndex++) {
+            int rowShift = rowIndex * PLAYER_ROW_STEP;
+            for (int slotIndex = 0; slotIndex < effectiveSlots; slotIndex++) {
+                Point base = PLAYER_BASE_POSITIONS.get(slotIndex);
+                int top = base.y + PLAYER_VERTICAL_OFFSET + rowShift;
+                int bottom = top + PLAYER_BOX_HEIGHT;
+                minOffset = Math.max(minOffset, -top);
+                maxOffset = Math.min(maxOffset, height - bottom);
+            }
+
+            int valueTop = SCORE_AREA.y + rowShift;
+            int valueBottom = valueTop + SCORE_AREA.height;
+            minOffset = Math.max(minOffset, -valueTop);
+            maxOffset = Math.min(maxOffset, height - valueBottom);
+        }
+
+        if (minOffset == Integer.MIN_VALUE) {
+            minOffset = -10;
+        }
+        if (maxOffset == Integer.MAX_VALUE) {
+            maxOffset = 135;
+        }
+        return new OffsetBounds(minOffset, maxOffset);
     }
 
     private RowsExtractionAttempt extractRowsForOffset(BufferedImage originalImage, BufferedImage preparedImage,
             ContributionMode declaredMode, int slotCount, List<Player> knownPlayers,
-            Map<String, Player> knownPlayersByName, int baseVerticalOffset) {
-        List<ContributionRunExtractionDto> result = new ArrayList<>();
+            Map<String, Player> knownPlayersByName, int baseVerticalOffset, int startRowIndex, int rowsToExtract) {
+        int limitedSlotCount = Math.min(slotCount, MAX_PLAYER_SLOTS);
+        int effectiveRows = Math.min(Math.max(rowsToExtract, 0), RUNS_PER_IMAGE - Math.max(startRowIndex, 0));
+        if (effectiveRows <= 0) {
+            return new RowsExtractionAttempt(List.of(), 0d, baseVerticalOffset);
+        }
+
+        List<ContributionRunExtractionDto> result = new ArrayList<>(effectiveRows);
         double confidenceSum = 0d;
         int confidenceCount = 0;
 
-        for (int rowIndex = 0; rowIndex < RUNS_PER_IMAGE; rowIndex++) {
+        for (int rowOffset = 0; rowOffset < effectiveRows; rowOffset++) {
+            int rowIndex = startRowIndex + rowOffset;
             int yOffset = baseVerticalOffset + rowIndex * PLAYER_ROW_STEP;
-            List<ContributionFieldExtractionDto> playerFields = new ArrayList<>(slotCount);
+            List<ContributionFieldExtractionDto> playerFields = new ArrayList<>(limitedSlotCount);
 
-            for (int slotIndex = 0; slotIndex < slotCount; slotIndex++) {
+            for (int slotIndex = 0; slotIndex < limitedSlotCount; slotIndex++) {
                 Point base = PLAYER_BASE_POSITIONS.get(slotIndex);
                 Rectangle playerRect = new Rectangle(base.x, base.y + yOffset + PLAYER_VERTICAL_OFFSET,
                         PLAYER_BOX_WIDTH, PLAYER_BOX_HEIGHT);
@@ -834,11 +929,11 @@ public class ContributorExtractionService {
                     time,
                     valueField,
                     playerFields,
-                    slotCount));
+                    limitedSlotCount));
         }
 
         double average = confidenceCount > 0 ? confidenceSum / confidenceCount : 0d;
-        return new RowsExtractionAttempt(result, average);
+        return new RowsExtractionAttempt(result, average, baseVerticalOffset);
     }
 
     private double fieldConfidenceOrZero(ContributionFieldExtractionDto field) {
@@ -1127,7 +1222,11 @@ public class ContributorExtractionService {
     private record DungeonMatch(Dungeon dungeon, String displayName) {
     }
 
-    private record RowsExtractionAttempt(List<ContributionRunExtractionDto> rows, double averageConfidence) {
+    private record RowsExtractionAttempt(List<ContributionRunExtractionDto> rows, double averageConfidence,
+            int baseOffset) {
+    }
+
+    private record OffsetBounds(int minOffset, int maxOffset) {
     }
 
     private record OcrResult(Rectangle area, BufferedImage original, BufferedImage preprocessed, String text,


### PR DESCRIPTION
## Summary
- scan leaderboard rows repeatedly with a sliding vertical offset to handle shifted captures
- accumulate confidences for player and value fields to choose the most reliable OCR result
- stop early when an attempt exceeds the 95% average confidence threshold

## Testing
- mvn test *(fails: requires external Maven dependencies, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d359f5477c832cabc8be206337ecca