### PR TITLE
Adjust row scan search bounds

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorExtractionService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorExtractionService.java
@@ -66,9 +66,9 @@ public class ContributorExtractionService {
     private static final int PLAYER_ROW_STEP = 134;
     private static final int PLAYER_VERTICAL_OFFSET = -3;
     private static final int ROW_SCAN_START_OFFSET = -16;
-    private static final int ROW_SCAN_MAX_OFFSET = 130;
+    private static final int ROW_SCAN_MAX_OFFSET = 70;
     private static final int ROW_SCAN_SWEEP_RANGE = ROW_SCAN_MAX_OFFSET - ROW_SCAN_START_OFFSET;
-    private static final int ROW_SCAN_STEP = 8;
+    private static final int ROW_SCAN_STEP = 4;
     private static final int RUNS_PER_IMAGE = 5;
     private static final List<Point> PLAYER_BASE_POSITIONS = List.of(
             new Point(920, 420),


### PR DESCRIPTION
## Summary
- reduce the vertical scan range for the first row detection to avoid overshooting lower content
- tighten the row scan step to keep coverage while reducing the search window

## Testing
- mvn -q test *(fails: dependency resolution blocked by lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d446f93fec832caea4519fae455ba2