### PR TITLE
Add entities for dungeon mutations

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationCurse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationCurse.java
@@ -1,0 +1,37 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing a mutation curse configuration.
+ */
+@Entity
+@Table(name = "mutation_curse")
+public class MutationCurse extends Auditable {
+
+    @Id
+    @Column(name = "id_mutation_curse", nullable = false, length = 64)
+    private String id;
+
+    @Column(name = "enable", nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private boolean enable = true;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationElement.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationElement.java
@@ -1,0 +1,37 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing a mutation element configuration.
+ */
+@Entity
+@Table(name = "mutation_element")
+public class MutationElement extends Auditable {
+
+    @Id
+    @Column(name = "id_mutation_element", nullable = false, length = 64)
+    private String id;
+
+    @Column(name = "enable", nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private boolean enable = true;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationPromotion.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationPromotion.java
@@ -1,0 +1,37 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing a mutation promotion configuration.
+ */
+@Entity
+@Table(name = "mutation_promotion")
+public class MutationPromotion extends Auditable {
+
+    @Id
+    @Column(name = "id_mutation_promotion", nullable = false, length = 64)
+    private String id;
+
+    @Column(name = "enable", nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private boolean enable = true;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationType.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/MutationType.java
@@ -1,0 +1,37 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entity representing a mutation type configuration.
+ */
+@Entity
+@Table(name = "mutation_type")
+public class MutationType extends Auditable {
+
+    @Id
+    @Column(name = "id_mutation_type", nullable = false, length = 64)
+    private String id;
+
+    @Column(name = "enable", nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private boolean enable = true;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeon.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeon.java
@@ -1,0 +1,104 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+/**
+ * Entity linking dungeon mutations configured for a specific week.
+ */
+@Entity
+@Table(name = "week_mutation_dungeon")
+public class WeekMutationDungeon extends Auditable {
+
+    @EmbeddedId
+    private WeekMutationDungeonId id;
+
+    @MapsId("dungeonId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_dungeon", nullable = false)
+    private Dungeon dungeon;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_mutation_element", nullable = false)
+    private MutationElement mutationElement;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_mutation_type", nullable = false)
+    private MutationType mutationType;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_mutation_promotion", nullable = false)
+    private MutationPromotion mutationPromotion;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_mutation_curse", nullable = false)
+    private MutationCurse mutationCurse;
+
+    public WeekMutationDungeonId getId() {
+        return id;
+    }
+
+    public void setId(WeekMutationDungeonId id) {
+        this.id = id;
+    }
+
+    public Integer getWeek() {
+        return id != null ? id.getWeek() : null;
+    }
+
+    public void setWeek(Integer week) {
+        if (id == null) {
+            id = new WeekMutationDungeonId();
+        }
+        id.setWeek(week);
+    }
+
+    public Dungeon getDungeon() {
+        return dungeon;
+    }
+
+    public void setDungeon(Dungeon dungeon) {
+        this.dungeon = dungeon;
+        if (id == null) {
+            id = new WeekMutationDungeonId();
+        }
+        id.setDungeonId(dungeon != null ? dungeon.getId() : null);
+    }
+
+    public MutationElement getMutationElement() {
+        return mutationElement;
+    }
+
+    public void setMutationElement(MutationElement mutationElement) {
+        this.mutationElement = mutationElement;
+    }
+
+    public MutationType getMutationType() {
+        return mutationType;
+    }
+
+    public void setMutationType(MutationType mutationType) {
+        this.mutationType = mutationType;
+    }
+
+    public MutationPromotion getMutationPromotion() {
+        return mutationPromotion;
+    }
+
+    public void setMutationPromotion(MutationPromotion mutationPromotion) {
+        this.mutationPromotion = mutationPromotion;
+    }
+
+    public MutationCurse getMutationCurse() {
+        return mutationCurse;
+    }
+
+    public void setMutationCurse(MutationCurse mutationCurse) {
+        this.mutationCurse = mutationCurse;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeonId.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeonId.java
@@ -1,0 +1,62 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Composite identifier for week mutation configuration per dungeon.
+ */
+@Embeddable
+public class WeekMutationDungeonId implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Column(name = "week", nullable = false)
+    private Integer week;
+
+    @Column(name = "id_dungeon", nullable = false)
+    private Long dungeonId;
+
+    public WeekMutationDungeonId() {
+    }
+
+    public WeekMutationDungeonId(Integer week, Long dungeonId) {
+        this.week = week;
+        this.dungeonId = dungeonId;
+    }
+
+    public Integer getWeek() {
+        return week;
+    }
+
+    public void setWeek(Integer week) {
+        this.week = week;
+    }
+
+    public Long getDungeonId() {
+        return dungeonId;
+    }
+
+    public void setDungeonId(Long dungeonId) {
+        this.dungeonId = dungeonId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WeekMutationDungeonId that = (WeekMutationDungeonId) o;
+        return Objects.equals(week, that.week) && Objects.equals(dungeonId, that.dungeonId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(week, dungeonId);
+    }
+}


### PR DESCRIPTION
## Summary
- add JPA entities for mutation element, type, promotion, and curse tables with enable flags
- create composite-identifier entity modelling weekly dungeon mutations and references to the new mutation tables

## Testing
- `mvn -q -DskipTests=false test` *(fails: cannot resolve Quarkus BOM because Maven Central is unreachable from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4584ce700832c885caa79555845ab