### PR TITLE
Fix SPA navigation refresh blank screen

### DIFF
--- a/nwleaderboard-ui/public/service-worker.js
+++ b/nwleaderboard-ui/public/service-worker.js
@@ -70,6 +70,16 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   if (event.request.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        const cache = await caches.open(CACHE_NAME);
+        const cachedResponse = await cache.match('/index.html');
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+        return fetch(event.request);
+      })()
+    );
     event.waitUntil(
       (async () => {
         const client = await self.clients.get(event.clientId);
@@ -78,6 +88,7 @@ self.addEventListener('fetch', (event) => {
         }
       })()
     );
+    return;
   }
   if (event.request.method !== 'GET') {
     event.respondWith(fetch(event.request));


### PR DESCRIPTION
## Summary
- serve the cached index.html when navigation requests hit the service worker
- keep navigation cache-complete messaging while preventing blank pages on sub-path refreshes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d62f4103a4832cbda408f1e82c5faa