### PR TITLE
Make page titles reflect active navigation

### DIFF
--- a/nwleaderboard-ui/js/pageTitle.js
+++ b/nwleaderboard-ui/js/pageTitle.js
@@ -1,0 +1,69 @@
+const SITE_NAME = 'New World Leaderboard';
+const SITE_TAGLINE = 'By oPy For Stats Lovers';
+const SITE_START_YEAR = 2025;
+
+function getYearRange(startYear = SITE_START_YEAR) {
+  const currentYear = new Date().getFullYear();
+  if (!Number.isFinite(currentYear) || currentYear <= startYear) {
+    return String(startYear);
+  }
+  return `${startYear}-${currentYear}`;
+}
+
+export function getBaseDocumentTitle() {
+  const yearRange = getYearRange();
+  return `${SITE_NAME} - ${SITE_TAGLINE} - ${yearRange}`;
+}
+
+export function formatDocumentTitle(pageTitle, options = {}) {
+  const baseTitle =
+    options && Object.prototype.hasOwnProperty.call(options, 'baseTitle')
+      ? options.baseTitle || ''
+      : getBaseDocumentTitle();
+  const appendSiteTitle =
+    options && Object.prototype.hasOwnProperty.call(options, 'append')
+      ? Boolean(options.append)
+      : true;
+  const separator =
+    options && Object.prototype.hasOwnProperty.call(options, 'separator')
+      ? options.separator || ' · '
+      : ' · ';
+
+  const trimmedTitle = typeof pageTitle === 'string' ? pageTitle.trim() : '';
+
+  if (!trimmedTitle) {
+    return baseTitle || '';
+  }
+
+  if (!appendSiteTitle || !baseTitle) {
+    return trimmedTitle;
+  }
+
+  return `${trimmedTitle}${separator}${baseTitle}`;
+}
+
+export function useDocumentTitle(pageTitle, options) {
+  const baseTitle =
+    options && Object.prototype.hasOwnProperty.call(options, 'baseTitle')
+      ? options.baseTitle || ''
+      : getBaseDocumentTitle();
+  const appendSiteTitle =
+    options && Object.prototype.hasOwnProperty.call(options, 'append')
+      ? Boolean(options.append)
+      : true;
+  const separator =
+    options && Object.prototype.hasOwnProperty.call(options, 'separator')
+      ? options.separator || ' · '
+      : ' · ';
+
+  React.useEffect(() => {
+    const formatted = formatDocumentTitle(pageTitle, {
+      baseTitle,
+      append: appendSiteTitle,
+      separator,
+    });
+    if (formatted) {
+      document.title = formatted;
+    }
+  }, [pageTitle, baseTitle, appendSiteTitle, separator]);
+}

--- a/nwleaderboard-ui/js/pages/Contribute.js
+++ b/nwleaderboard-ui/js/pages/Contribute.js
@@ -1,5 +1,6 @@
 import { LangContext } from '../i18n.js';
 import PageSubmenu from '../components/PageSubmenu.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const { NavLink, Outlet, useLocation } = ReactRouterDOM;
 
@@ -9,6 +10,8 @@ export default function Contribute() {
   const location = useLocation();
   const isValidateRoute = location?.pathname?.startsWith('/contribute/validate');
   const pageClassName = `page contribute-page${isValidateRoute ? ' contribute-page--wide' : ''}`;
+
+  useDocumentTitle(t.contributeTitle);
 
   return (
     <main className={pageClassName} aria-labelledby="contribute-title">

--- a/nwleaderboard-ui/js/pages/ContributeDungeons.js
+++ b/nwleaderboard-ui/js/pages/ContributeDungeons.js
@@ -1,5 +1,6 @@
 import { LangContext } from '../i18n.js';
 import { getDungeonNameForLang, normaliseDungeons, sortDungeons, toPositiveInteger } from '../dungeons.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
 
@@ -27,6 +28,14 @@ export default function ContributeDungeons() {
   const [error, setError] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
   const [feedback, setFeedback] = React.useState({ type: '', text: '' });
+
+  const sectionTitle = React.useMemo(() => {
+    const section = t.contributeMenuDungeons || t.dungeons || 'Dungeons';
+    const base = t.contributeTitle || '';
+    return base ? `${base} – ${section}` : section;
+  }, [t]);
+
+  useDocumentTitle(sectionTitle);
 
   React.useEffect(() => {
     let active = true;

--- a/nwleaderboard-ui/js/pages/ContributeImport.js
+++ b/nwleaderboard-ui/js/pages/ContributeImport.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const { Link } = ReactRouterDOM;
 
@@ -37,6 +38,14 @@ export default function ContributeImport() {
   const [errorKey, setErrorKey] = React.useState('');
   const [errorText, setErrorText] = React.useState('');
   const [processingNow, setProcessingNow] = React.useState(() => Date.now());
+
+  const sectionTitle = React.useMemo(() => {
+    const section = t.contributeMenuImport || t.contribute || 'Import';
+    const base = t.contributeTitle || '';
+    return base ? `${base} – ${section}` : section;
+  }, [t]);
+
+  useDocumentTitle(sectionTitle);
 
   const resetFeedback = React.useCallback(() => {
     setMessageKey('');

--- a/nwleaderboard-ui/js/pages/ContributePlayers.js
+++ b/nwleaderboard-ui/js/pages/ContributePlayers.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
 
@@ -58,6 +59,14 @@ export default function ContributePlayers() {
   const [editingName, setEditingName] = React.useState('');
   const [pendingIds, setPendingIds] = React.useState(() => new Set());
   const [feedback, setFeedback] = React.useState({ type: '', text: '' });
+
+  const sectionTitle = React.useMemo(() => {
+    const section = t.contributeMenuPlayers || t.contributePlayers || 'Players';
+    const base = t.contributeTitle || '';
+    return base ? `${base} – ${section}` : section;
+  }, [t]);
+
+  useDocumentTitle(sectionTitle);
 
   const formatRunCounts = React.useCallback(
     (total, score, time) => {

--- a/nwleaderboard-ui/js/pages/ContributeStats.js
+++ b/nwleaderboard-ui/js/pages/ContributeStats.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
 
@@ -7,6 +8,14 @@ export default function ContributeStats() {
   const [stats, setStats] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState('');
+
+  const sectionTitle = React.useMemo(() => {
+    const section = t.contributeMenuStats || t.contributeStats || 'Weekly runs';
+    const base = t.contributeTitle || '';
+    return base ? `${base} – ${section}` : section;
+  }, [t]);
+
+  useDocumentTitle(sectionTitle);
 
   React.useEffect(() => {
     let active = true;

--- a/nwleaderboard-ui/js/pages/ContributeValidate.js
+++ b/nwleaderboard-ui/js/pages/ContributeValidate.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
 const DEFAULT_PLAYER_SLOTS = 6;
@@ -384,6 +385,14 @@ export default function ContributeValidate() {
   const [loadingDetail, setLoadingDetail] = React.useState(false);
   const [compactView, setCompactView] = React.useState(false);
   const [savingDraft, setSavingDraft] = React.useState(false);
+
+  const sectionTitle = React.useMemo(() => {
+    const section = t.contributeMenuValidate || 'Validate';
+    const base = t.contributeTitle || '';
+    return base ? `${base} – ${section}` : section;
+  }, [t]);
+
+  useDocumentTitle(sectionTitle);
 
   const getConfidenceLabel = React.useCallback((confidence) => formatConfidenceLabel(t, confidence), [t]);
 

--- a/nwleaderboard-ui/js/pages/ForgotPassword.js
+++ b/nwleaderboard-ui/js/pages/ForgotPassword.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 export default function ForgotPassword() {
   const { t } = React.useContext(LangContext);
@@ -36,6 +37,8 @@ export default function ForgotPassword() {
       setMessage(t.forgotError);
     }
   };
+
+  useDocumentTitle(t.forgotPassword);
 
   return (
     <main className="page" aria-labelledby="forgot-title">

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -9,6 +9,7 @@ import {
   toPositiveInteger,
 } from '../dungeons.js';
 import { capitaliseWords } from '../text.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const { Link } = ReactRouterDOM;
 
@@ -132,6 +133,8 @@ export default function Home() {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(false);
   const pageTitle = capitaliseWords(t.leaderboardTitle || '');
+
+  useDocumentTitle(pageTitle);
 
   React.useEffect(() => {
     let active = true;

--- a/nwleaderboard-ui/js/pages/Individual.js
+++ b/nwleaderboard-ui/js/pages/Individual.js
@@ -1,5 +1,7 @@
 import { LangContext } from '../i18n.js';
 import HomeMenu from '../components/HomeMenu.js';
+import { capitaliseWords } from '../text.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const { Link } = ReactRouterDOM;
 
@@ -20,6 +22,26 @@ export default function Individual() {
   const [entries, setEntries] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(false);
+
+  const baseTitle = React.useMemo(() => capitaliseWords(t.individualTitle || ''), [t]);
+  const activeModeLabel = React.useMemo(() => {
+    if (mode === 'score') {
+      return capitaliseWords(t.individualModeScore || '');
+    }
+    if (mode === 'time') {
+      return capitaliseWords(t.individualModeTime || '');
+    }
+    return capitaliseWords(t.individualModeGlobal || '');
+  }, [mode, t]);
+
+  const documentTitle = React.useMemo(() => {
+    if (activeModeLabel) {
+      return `${baseTitle} – ${activeModeLabel}`;
+    }
+    return baseTitle;
+  }, [baseTitle, activeModeLabel]);
+
+  useDocumentTitle(documentTitle);
 
   React.useEffect(() => {
     let active = true;

--- a/nwleaderboard-ui/js/pages/LeaderboardPage.js
+++ b/nwleaderboard-ui/js/pages/LeaderboardPage.js
@@ -4,6 +4,7 @@ import ChartCanvas from '../components/ChartCanvas.js';
 import DungeonIcon from '../components/DungeonIcon.js';
 import { getDungeonNameForLang, normaliseDungeons, sortDungeons } from '../dungeons.js';
 import { capitaliseWords } from '../text.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const { Link } = ReactRouterDOM;
 
@@ -109,6 +110,28 @@ export default function LeaderboardPage({
   const [entries, setEntries] = React.useState([]);
   const [entriesLoading, setEntriesLoading] = React.useState(false);
   const [entriesError, setEntriesError] = React.useState(false);
+
+  const displayTitle = React.useMemo(() => capitaliseWords(pageTitle || ''), [pageTitle]);
+
+  const activeDungeonName = React.useMemo(() => {
+    if (!selectedDungeon) {
+      return '';
+    }
+    const found = dungeons.find((dungeon) => dungeon.id === selectedDungeon);
+    if (!found) {
+      return '';
+    }
+    return getDungeonNameForLang(found, lang);
+  }, [dungeons, selectedDungeon, lang]);
+
+  const documentTitle = React.useMemo(() => {
+    if (activeDungeonName) {
+      return `${displayTitle} – ${activeDungeonName}`;
+    }
+    return displayTitle;
+  }, [displayTitle, activeDungeonName]);
+
+  useDocumentTitle(documentTitle);
 
   React.useEffect(() => {
     let active = true;
@@ -495,8 +518,6 @@ export default function LeaderboardPage({
   const handleSelectDungeon = React.useCallback((dungeonId) => {
     setSelectedDungeon(dungeonId);
   }, []);
-
-  const displayTitle = React.useMemo(() => capitaliseWords(pageTitle || ''), [pageTitle]);
 
   return (
     <main className="page leaderboard-page" aria-labelledby={`${mode}-title`}>

--- a/nwleaderboard-ui/js/pages/Login.js
+++ b/nwleaderboard-ui/js/pages/Login.js
@@ -1,5 +1,6 @@
 import { LangContext } from '../i18n.js';
 import { loginWithPassword } from '../auth.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 export default function Login({ onLogin }) {
   const { t, lang, changeLang } = React.useContext(LangContext);
@@ -22,6 +23,8 @@ export default function Login({ onLogin }) {
   const preventCopyPaste = (event) => {
     event.preventDefault();
   };
+
+  useDocumentTitle(t.login);
 
   const handleSubmit = async (event) => {
     event.preventDefault();

--- a/nwleaderboard-ui/js/pages/Password.js
+++ b/nwleaderboard-ui/js/pages/Password.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 export default function Password() {
   const { t } = React.useContext(LangContext);
@@ -68,6 +69,8 @@ export default function Password() {
       setMessage(t.passwordError);
     }
   };
+
+  useDocumentTitle(t.password);
 
   return (
     <main className="page" aria-labelledby="password-title">

--- a/nwleaderboard-ui/js/pages/Player.js
+++ b/nwleaderboard-ui/js/pages/Player.js
@@ -4,6 +4,7 @@ import HomeMenu from '../components/HomeMenu.js';
 import ChartCanvas from '../components/ChartCanvas.js';
 import DungeonIcon from '../components/DungeonIcon.js';
 import { capitaliseWords } from '../text.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const { Link, useNavigate, useParams } = ReactRouterDOM;
 
@@ -529,6 +530,8 @@ export default function Player() {
     }
     return capitaliseWords(t.playerNotFoundTitle || '');
   }, [hasPlayerId, playerDisplayName, loading, t]);
+
+  useDocumentTitle(heading);
 
   const headingIconId = React.useMemo(() => {
     for (const dungeon of preparedDungeons) {

--- a/nwleaderboard-ui/js/pages/Preferences.js
+++ b/nwleaderboard-ui/js/pages/Preferences.js
@@ -1,5 +1,6 @@
 import { LangContext } from '../i18n.js';
 import { ThemeContext } from '../theme.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 const { useNavigate } = ReactRouterDOM;
 
@@ -19,6 +20,8 @@ export default function Preferences() {
   const { theme, toggleTheme } = React.useContext(ThemeContext);
   const [messageKey, setMessageKey] = React.useState('');
   const navigate = useNavigate();
+
+  useDocumentTitle(t.preferences);
 
   const handleLanguageChange = (event) => {
     changeLang(event.target.value);

--- a/nwleaderboard-ui/js/pages/Register.js
+++ b/nwleaderboard-ui/js/pages/Register.js
@@ -1,4 +1,5 @@
 import { LangContext } from '../i18n.js';
+import { useDocumentTitle } from '../pageTitle.js';
 
 export default function Register() {
   const { t } = React.useContext(LangContext);
@@ -22,6 +23,8 @@ export default function Register() {
   const preventCopyPaste = (event) => {
     event.preventDefault();
   };
+
+  useDocumentTitle(t.register);
 
   const handleSubmit = async (event) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- add a shared page title helper that builds the site tagline and year range
- update the main navigation and contributor pages to call the helper so document titles match the active view
- include the selected dungeon name when showing leaderboard titles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d658ed8eb0832c848d6438a7493702