### PR TITLE
Add persistent site header layout

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -75,6 +75,52 @@ body[data-theme='light'] {
   min-height: 0;
 }
 
+.app-shell {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: clamp(0.85rem, 2vw, 1.25rem);
+  padding: clamp(1.1rem, 2.8vw, 1.75rem) clamp(1.25rem, 4vw, 2.25rem);
+  background: var(--surface-dark);
+  border-bottom: 1px solid var(--border-dark);
+  box-shadow: 0 18px 30px rgba(5, 8, 20, 0.65);
+  backdrop-filter: blur(18px);
+}
+
+body[data-theme='light'] .site-header {
+  background: var(--surface-light);
+  border-bottom-color: var(--border-light);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
+}
+
+.site-header__logo {
+  width: clamp(2.25rem, 4vw, 2.75rem);
+  height: clamp(2.25rem, 4vw, 2.75rem);
+  flex-shrink: 0;
+}
+
+.site-header__title {
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.app-content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .page {
   flex: 1 1 auto;
   padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1rem, 5vw, 1.75rem)

--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -28,6 +28,8 @@ import {
 
 const { BrowserRouter, Routes, Route, Navigate } = ReactRouterDOM;
 
+const SITE_ICON_URL = new URL('../images/icons/logo.svg', import.meta.url).href;
+
 export default function App() {
   const [authState, setAuthState] = React.useState(() => {
     const stored = getStoredTokens();
@@ -36,6 +38,8 @@ export default function App() {
       canContribute: hasContributorRole(stored),
     };
   });
+  const currentYear = new Date().getFullYear();
+  const siteTitle = `New World Leaderboard - By oPy For Stats Lovers - 2025-${currentYear}`;
 
   const handleLogout = React.useCallback(() => {
     setAuthState({ token: null, canContribute: false });
@@ -69,60 +73,72 @@ export default function App() {
   return (
     <>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/score" element={<Score />} />
-          <Route path="/time" element={<Time />} />
-          <Route path="/individual" element={<Individual />} />
-          <Route
-            path="/login"
-            element={
-              authenticated ? (
-                <Navigate to="/" replace />
-              ) : (
-                <Login onLogin={handleLogin} />
-              )
-            }
+        <div className="app-shell">
+          <header className="site-header" role="banner">
+            <img
+              src={SITE_ICON_URL}
+              alt="New World Leaderboard"
+              className="site-header__logo"
+            />
+            <span className="site-header__title">{siteTitle}</span>
+          </header>
+          <main className="app-content" role="main">
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/score" element={<Score />} />
+              <Route path="/time" element={<Time />} />
+              <Route path="/individual" element={<Individual />} />
+              <Route
+                path="/login"
+                element={
+                  authenticated ? (
+                    <Navigate to="/" replace />
+                  ) : (
+                    <Login onLogin={handleLogin} />
+                  )
+                }
+              />
+              <Route path="/register" element={<Register />} />
+              <Route path="/forgot-password" element={<ForgotPassword />} />
+              <Route
+                path="/password"
+                element={
+                  authenticated ? <Password /> : <Navigate to="/login" replace />
+                }
+              />
+              <Route
+                path="/preferences"
+                element={
+                  authenticated ? <Preferences /> : <Navigate to="/login" replace />
+                }
+              />
+              <Route
+                path="/contribute/*"
+                element={
+                  authenticated && authState.canContribute ? (
+                    <Contribute />
+                  ) : (
+                    <Navigate to="/" replace />
+                  )
+                }
+              >
+                <Route index element={<ContributeDungeons />} />
+                <Route path="import" element={<ContributeImport />} />
+                <Route path="validate" element={<ContributeValidate />} />
+                <Route path="stats" element={<ContributeStats />} />
+                <Route path="players" element={<ContributePlayers />} />
+                <Route path="*" element={<Navigate to="." replace />} />
+              </Route>
+              <Route path="/player/:playerId?" element={<Player />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </main>
+          <BottomNav
+            authenticated={authenticated}
+            canContribute={authState.canContribute}
+            onLogout={handleLogout}
           />
-          <Route path="/register" element={<Register />} />
-          <Route path="/forgot-password" element={<ForgotPassword />} />
-          <Route
-            path="/password"
-            element={
-              authenticated ? <Password /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/preferences"
-            element={
-              authenticated ? <Preferences /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/contribute/*"
-            element={
-              authenticated && authState.canContribute ? (
-                <Contribute />
-              ) : (
-                <Navigate to="/" replace />
-              )
-            }
-          >
-            <Route index element={<ContributeDungeons />} />
-            <Route path="import" element={<ContributeImport />} />
-            <Route path="validate" element={<ContributeValidate />} />
-            <Route path="stats" element={<ContributeStats />} />
-            <Route path="players" element={<ContributePlayers />} />
-            <Route path="*" element={<Navigate to="." replace />} />
-          </Route>
-          <Route path="/player/:playerId?" element={<Player />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-        <BottomNav
-          authenticated={authenticated}
-          canContribute={authState.canContribute}
-          onLogout={handleLogout}
-        />
+        </div>
       </BrowserRouter>
       <VersionChecker />
     </>


### PR DESCRIPTION
## Summary
- add a persistent shell around the router with a static site header and icon
- keep the bottom navigation outside of routed content while ensuring all pages render within the shell
- style the new header and layout for both light and dark themes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d65d416200832cbd127663d4c681dd