### PR TITLE
Support direct leaderboard URLs with optional dungeon selection

### DIFF
--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -79,9 +79,13 @@ export default function App() {
           <main className="site-main">
             <Routes>
               <Route path="/" element={<Home />} />
-              <Route path="/score" element={<Score />} />
-              <Route path="/time" element={<Time />} />
+              <Route path="/score/:dungeonId?" element={<Score />} />
+              <Route path="/time/:dungeonId?" element={<Time />} />
               <Route path="/individual" element={<Individual />} />
+              <Route path="/leaderboard/score/:dungeonId?" element={<Score />} />
+              <Route path="/leaderboard/time/:dungeonId?" element={<Time />} />
+              <Route path="/leaderboard/individual" element={<Individual />} />
+              <Route path="/leaderboard" element={<Navigate to="/leaderboard/score" replace />} />
               <Route
                 path="/login"
                 element={

--- a/nwleaderboard-ui/js/Header.js
+++ b/nwleaderboard-ui/js/Header.js
@@ -42,6 +42,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
   const showContribute = isAuthenticated && Boolean(canContribute);
   const contributeActive = location.pathname.startsWith('/contribute');
   const leaderboardActive =
+    location.pathname.startsWith('/leaderboard') ||
     location.pathname.startsWith('/score') ||
     location.pathname.startsWith('/time') ||
     location.pathname.startsWith('/individual');
@@ -235,7 +236,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                 {...createMenuHandlers('leaderboard')}
               >
                 <SiteNavLink
-                  to="/score"
+                  to="/leaderboard/score"
                   className="site-nav__link--parent"
                   isActiveOverride={leaderboardActive}
                   aria-haspopup="true"
@@ -254,7 +255,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                 >
                   <li>
                     <SiteNavLink
-                      to="/score"
+                      to="/leaderboard/score"
                       className="site-nav__sublink"
                       end
                       onClick={closeMenus}
@@ -264,7 +265,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                   </li>
                   <li>
                     <SiteNavLink
-                      to="/time"
+                      to="/leaderboard/time"
                       className="site-nav__sublink"
                       end
                       onClick={closeMenus}
@@ -274,7 +275,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                   </li>
                   <li>
                     <SiteNavLink
-                      to="/individual"
+                      to="/leaderboard/individual"
                       className="site-nav__sublink"
                       end
                       onClick={closeMenus}

--- a/nwleaderboard-ui/js/pages/Individual.js
+++ b/nwleaderboard-ui/js/pages/Individual.js
@@ -1,5 +1,5 @@
 import { LangContext } from '../i18n.js';
-const { Link } = ReactRouterDOM;
+const { Link, useLocation, useNavigate } = ReactRouterDOM;
 
 const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
 
@@ -18,6 +18,14 @@ export default function Individual() {
   const [entries, setEntries] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (location.pathname === '/individual') {
+      navigate('/leaderboard/individual', { replace: true });
+    }
+  }, [location.pathname, navigate]);
 
   React.useEffect(() => {
     let active = true;


### PR DESCRIPTION
## Summary
- add /leaderboard routes for score, time, and individual leaderboard pages
- sync dungeon selection with URL parameters and handle invalid selections gracefully
- redirect legacy score, time, and individual paths to the new leaderboard URLs and update navigation links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d71180e57c832ca483ed8ac3810dcb