### PR TITLE
Support direct leaderboard routes

### DIFF
--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -82,6 +82,12 @@ export default function App() {
               <Route path="/score" element={<Score />} />
               <Route path="/time" element={<Time />} />
               <Route path="/individual" element={<Individual />} />
+              <Route path="/leaderboard" element={<Navigate to="/score" replace />} />
+              <Route path="/leaderboard/score" element={<Score />} />
+              <Route path="/leaderboard/score/:dungeonId" element={<Score />} />
+              <Route path="/leaderboard/time" element={<Time />} />
+              <Route path="/leaderboard/time/:dungeonId" element={<Time />} />
+              <Route path="/leaderboard/individual" element={<Individual />} />
               <Route
                 path="/login"
                 element={

--- a/nwleaderboard-ui/js/pages/LeaderboardPage.js
+++ b/nwleaderboard-ui/js/pages/LeaderboardPage.js
@@ -100,6 +100,7 @@ export default function LeaderboardPage({
   sortDirection = 'desc',
   chartConfig,
   showDungeonIconInTitle = true,
+  initialDungeonId = null,
 }) {
   const { t, lang } = React.useContext(LangContext);
   const [dungeons, setDungeons] = React.useState([]);
@@ -152,7 +153,7 @@ export default function LeaderboardPage({
 
   React.useEffect(() => {
     if (!Array.isArray(dungeons) || dungeons.length === 0) {
-      setSelectedDungeon((previous) => (previous === null ? previous : null));
+      setSelectedDungeon(null);
       return;
     }
     setSelectedDungeon((previous) => {
@@ -163,6 +164,20 @@ export default function LeaderboardPage({
       return first ? first.id : null;
     });
   }, [dungeons, lang]);
+
+  React.useEffect(() => {
+    if (initialDungeonId === undefined || initialDungeonId === null || initialDungeonId === '') {
+      return;
+    }
+    if (!Array.isArray(dungeons) || dungeons.length === 0) {
+      return;
+    }
+    const normalisedId = String(initialDungeonId);
+    if (!dungeons.some((dungeon) => dungeon.id === normalisedId)) {
+      return;
+    }
+    setSelectedDungeon((previous) => (previous === normalisedId ? previous : normalisedId));
+  }, [initialDungeonId, dungeons]);
 
   React.useEffect(() => {
     if (!selectedDungeon) {

--- a/nwleaderboard-ui/js/pages/Score.js
+++ b/nwleaderboard-ui/js/pages/Score.js
@@ -2,6 +2,8 @@ import LeaderboardPage from './LeaderboardPage.js';
 import { LangContext } from '../i18n.js';
 import { capitaliseWords } from '../text.js';
 
+const { useParams } = ReactRouterDOM;
+
 function parseScoreValue(value) {
   if (value === undefined || value === null || value === '') {
     return Number.NaN;
@@ -42,7 +44,9 @@ function formatScore(value) {
 
 export default function Score() {
   const { t } = React.useContext(LangContext);
+  const { dungeonId } = useParams();
   const pageTitle = capitaliseWords(t.scoreTitle || '');
+  const initialDungeonId = dungeonId ? String(dungeonId) : null;
 
   const chartConfig = React.useMemo(
     () => ({
@@ -90,6 +94,7 @@ export default function Score() {
       sortDirection="desc"
       chartConfig={chartConfig}
       showDungeonIconInTitle={false}
+      initialDungeonId={initialDungeonId}
     />
   );
 }

--- a/nwleaderboard-ui/js/pages/Time.js
+++ b/nwleaderboard-ui/js/pages/Time.js
@@ -2,6 +2,8 @@ import LeaderboardPage from './LeaderboardPage.js';
 import { LangContext } from '../i18n.js';
 import { capitaliseWords } from '../text.js';
 
+const { useParams } = ReactRouterDOM;
+
 function toSeconds(value) {
   if (value === undefined || value === null || value === '') {
     return Number.NaN;
@@ -65,7 +67,9 @@ function formatTime(value) {
 
 export default function Time() {
   const { t } = React.useContext(LangContext);
+  const { dungeonId } = useParams();
   const pageTitle = capitaliseWords(t.timeTitle || '');
+  const initialDungeonId = dungeonId ? String(dungeonId) : null;
 
   const chartConfig = React.useMemo(
     () => ({
@@ -114,6 +118,7 @@ export default function Time() {
       sortDirection="asc"
       chartConfig={chartConfig}
       showDungeonIconInTitle={false}
+      initialDungeonId={initialDungeonId}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add `/leaderboard/*` routes so direct navigation reaches the intended leaderboard views
- allow the score and time pages to read the dungeon id from URL params for preselection
- initialise the shared leaderboard page with a dungeon id when provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d71410a5fc832c915d19bacdd2fc27