### PR TITLE
Support direct leaderboard routing

### DIFF
--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -79,8 +79,16 @@ export default function App() {
           <main className="site-main">
             <Routes>
               <Route path="/" element={<Home />} />
+              <Route path="/leaderboard" element={<Navigate to="/leaderboard/score" replace />} />
+              <Route path="/leaderboard/score" element={<Score />} />
+              <Route path="/leaderboard/score/:dungeonId" element={<Score />} />
+              <Route path="/leaderboard/time" element={<Time />} />
+              <Route path="/leaderboard/time/:dungeonId" element={<Time />} />
+              <Route path="/leaderboard/individual" element={<Individual />} />
               <Route path="/score" element={<Score />} />
+              <Route path="/score/:dungeonId" element={<Score />} />
               <Route path="/time" element={<Time />} />
+              <Route path="/time/:dungeonId" element={<Time />} />
               <Route path="/individual" element={<Individual />} />
               <Route
                 path="/login"

--- a/nwleaderboard-ui/js/Header.js
+++ b/nwleaderboard-ui/js/Header.js
@@ -42,6 +42,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
   const showContribute = isAuthenticated && Boolean(canContribute);
   const contributeActive = location.pathname.startsWith('/contribute');
   const leaderboardActive =
+    location.pathname.startsWith('/leaderboard') ||
     location.pathname.startsWith('/score') ||
     location.pathname.startsWith('/time') ||
     location.pathname.startsWith('/individual');
@@ -235,7 +236,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                 {...createMenuHandlers('leaderboard')}
               >
                 <SiteNavLink
-                  to="/score"
+                  to="/leaderboard/score"
                   className="site-nav__link--parent"
                   isActiveOverride={leaderboardActive}
                   aria-haspopup="true"
@@ -254,7 +255,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                 >
                   <li>
                     <SiteNavLink
-                      to="/score"
+                      to="/leaderboard/score"
                       className="site-nav__sublink"
                       end
                       onClick={closeMenus}
@@ -264,7 +265,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                   </li>
                   <li>
                     <SiteNavLink
-                      to="/time"
+                      to="/leaderboard/time"
                       className="site-nav__sublink"
                       end
                       onClick={closeMenus}
@@ -274,7 +275,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                   </li>
                   <li>
                     <SiteNavLink
-                      to="/individual"
+                      to="/leaderboard/individual"
                       className="site-nav__sublink"
                       end
                       onClick={closeMenus}

--- a/nwleaderboard-ui/js/pages/Score.js
+++ b/nwleaderboard-ui/js/pages/Score.js
@@ -2,6 +2,8 @@ import LeaderboardPage from './LeaderboardPage.js';
 import { LangContext } from '../i18n.js';
 import { capitaliseWords } from '../text.js';
 
+const { useParams, useNavigate } = ReactRouterDOM;
+
 function parseScoreValue(value) {
   if (value === undefined || value === null || value === '') {
     return Number.NaN;
@@ -43,6 +45,9 @@ function formatScore(value) {
 export default function Score() {
   const { t } = React.useContext(LangContext);
   const pageTitle = capitaliseWords(t.scoreTitle || '');
+  const navigate = useNavigate();
+  const params = useParams();
+  const dungeonId = params?.dungeonId ? String(params.dungeonId) : null;
 
   const chartConfig = React.useMemo(
     () => ({
@@ -80,6 +85,20 @@ export default function Score() {
 
   const getSortValue = React.useCallback((entry) => parseScoreValue(entry.value), []);
 
+  const handleDungeonChange = React.useCallback(
+    (nextDungeonId) => {
+      if (!nextDungeonId) {
+        navigate('/leaderboard/score', { replace: false });
+        return;
+      }
+      if (nextDungeonId === dungeonId) {
+        return;
+      }
+      navigate(`/leaderboard/score/${encodeURIComponent(nextDungeonId)}`);
+    },
+    [navigate, dungeonId],
+  );
+
   return (
     <LeaderboardPage
       mode="score"
@@ -90,6 +109,8 @@ export default function Score() {
       sortDirection="desc"
       chartConfig={chartConfig}
       showDungeonIconInTitle={false}
+      selectedDungeonId={dungeonId}
+      onDungeonChange={handleDungeonChange}
     />
   );
 }

--- a/nwleaderboard-ui/js/pages/Time.js
+++ b/nwleaderboard-ui/js/pages/Time.js
@@ -2,6 +2,8 @@ import LeaderboardPage from './LeaderboardPage.js';
 import { LangContext } from '../i18n.js';
 import { capitaliseWords } from '../text.js';
 
+const { useParams, useNavigate } = ReactRouterDOM;
+
 function toSeconds(value) {
   if (value === undefined || value === null || value === '') {
     return Number.NaN;
@@ -66,6 +68,9 @@ function formatTime(value) {
 export default function Time() {
   const { t } = React.useContext(LangContext);
   const pageTitle = capitaliseWords(t.timeTitle || '');
+  const navigate = useNavigate();
+  const params = useParams();
+  const dungeonId = params?.dungeonId ? String(params.dungeonId) : null;
 
   const chartConfig = React.useMemo(
     () => ({
@@ -104,6 +109,20 @@ export default function Time() {
 
   const getSortValue = React.useCallback((entry) => toSeconds(entry.value), []);
 
+  const handleDungeonChange = React.useCallback(
+    (nextDungeonId) => {
+      if (!nextDungeonId) {
+        navigate('/leaderboard/time', { replace: false });
+        return;
+      }
+      if (nextDungeonId === dungeonId) {
+        return;
+      }
+      navigate(`/leaderboard/time/${encodeURIComponent(nextDungeonId)}`);
+    },
+    [navigate, dungeonId],
+  );
+
   return (
     <LeaderboardPage
       mode="time"
@@ -114,6 +133,8 @@ export default function Time() {
       sortDirection="asc"
       chartConfig={chartConfig}
       showDungeonIconInTitle={false}
+      selectedDungeonId={dungeonId}
+      onDungeonChange={handleDungeonChange}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add explicit /leaderboard routes with optional dungeon ids for score and time views
- sync navigation with the new leaderboard paths and keep legacy paths working
- allow leaderboard pages to pre-select dungeons based on the active route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d71410a5fc832c915d19bacdd2fc27