### PR TITLE
Add ranking position metadata and badges

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightMetricResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightMetricResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 public record HighlightMetricResponse(
         Integer value,
         Integer week,
+        Integer position,
         List<LeaderboardPlayerResponse> players,
         @JsonProperty("mutation_type_id") String mutationTypeId,
         @JsonProperty("mutation_promotion_id") String mutationPromotionId,

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardEntryResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardEntryResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LeaderboardEntryResponse(
         Long entryId,
+        Integer position,
         Integer week,
         Integer value,
         Integer score,

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerDungeonBestResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerDungeonBestResponse.java
@@ -11,10 +11,12 @@ public record PlayerDungeonBestResponse(
         Map<String, String> names,
         Integer bestScore,
         Integer bestScoreWeek,
+        Integer bestScorePosition,
         Integer minScore,
         Integer maxScore,
         Integer bestTime,
         Integer bestTimeWeek,
+        Integer bestTimePosition,
         Integer minTime,
         Integer maxTime) {
 

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
@@ -68,12 +68,15 @@ public class LeaderboardService {
         Map<Long, List<LeaderboardPlayerResponse>> playersByRun = loadPlayersForScoreRuns(runs);
         Map<MutationKey, MutationIds> mutationCache = new HashMap<>();
         List<LeaderboardEntryResponse> responses = new ArrayList<>(runs.size());
-        for (RunScore run : runs) {
+        for (int index = 0; index < runs.size(); index++) {
+            RunScore run = runs.get(index);
             Long runId = run.getId();
             Integer score = run.getScore();
+            Integer position = index + 1;
             MutationIds mutationIds = resolveMutationIds(run.getWeek(), run.getDungeon(), mutationCache);
             responses.add(new LeaderboardEntryResponse(
                     runId,
+                    position,
                     run.getWeek(),
                     score,
                     score,
@@ -99,12 +102,15 @@ public class LeaderboardService {
         Map<Long, List<LeaderboardPlayerResponse>> playersByRun = loadPlayersForTimeRuns(runs);
         Map<MutationKey, MutationIds> mutationCache = new HashMap<>();
         List<LeaderboardEntryResponse> responses = new ArrayList<>(runs.size());
-        for (RunTime run : runs) {
+        for (int index = 0; index < runs.size(); index++) {
+            RunTime run = runs.get(index);
             Long runId = run.getId();
             Integer time = run.getTimeInSecond();
+            Integer position = index + 1;
             MutationIds mutationIds = resolveMutationIds(run.getWeek(), run.getDungeon(), mutationCache);
             responses.add(new LeaderboardEntryResponse(
                     runId,
+                    position,
                     run.getWeek(),
                     time,
                     null,
@@ -162,10 +168,12 @@ public class LeaderboardService {
                     bestScore != null ? bestScore.getWeek() : null,
                     bestScore != null ? bestScore.getDungeon() : null,
                     mutationCache);
+            Integer scorePosition = bestScore != null ? runScoreRepository.findPositionInDungeon(bestScore) : null;
             HighlightMetricResponse scoreMetric = bestScore != null
                     ? new HighlightMetricResponse(
                             bestScore.getScore(),
                             bestScore.getWeek(),
+                            scorePosition,
                             scorePlayersByRun.getOrDefault(bestScore.getId(), List.of()),
                             scoreMutations.typeId(),
                             scoreMutations.promotionId(),
@@ -175,10 +183,12 @@ public class LeaderboardService {
                     bestTime != null ? bestTime.getWeek() : null,
                     bestTime != null ? bestTime.getDungeon() : null,
                     mutationCache);
+            Integer timePosition = bestTime != null ? runTimeRepository.findPositionInDungeon(bestTime) : null;
             HighlightMetricResponse timeMetric = bestTime != null
                     ? new HighlightMetricResponse(
                             bestTime.getTimeInSecond(),
                             bestTime.getWeek(),
+                            timePosition,
                             timePlayersByRun.getOrDefault(bestTime.getId(), List.of()),
                             timeMutations.typeId(),
                             timeMutations.promotionId(),

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/PlayerProfileService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/PlayerProfileService.java
@@ -137,10 +137,12 @@ public class PlayerProfileService {
         RunTime bestTime = aggregate.bestTime;
         Integer scoreValue = bestScore != null ? bestScore.getScore() : null;
         Integer scoreWeek = bestScore != null ? bestScore.getWeek() : null;
+        Integer scorePosition = bestScore != null ? runScoreRepository.findPositionInDungeon(bestScore) : null;
         Integer minScore = aggregate.minScore;
         Integer maxScore = aggregate.maxScore;
         Integer timeValue = bestTime != null ? bestTime.getTimeInSecond() : null;
         Integer timeWeek = bestTime != null ? bestTime.getWeek() : null;
+        Integer timePosition = bestTime != null ? runTimeRepository.findPositionInDungeon(bestTime) : null;
         Integer minTime = aggregate.minTime;
         Integer maxTime = aggregate.maxTime;
         Long dungeonId = dungeon != null ? dungeon.getId() : null;
@@ -150,10 +152,12 @@ public class PlayerProfileService {
                 names,
                 scoreValue,
                 scoreWeek,
+                scorePosition,
                 minScore,
                 maxScore,
                 timeValue,
                 timeWeek,
+                timePosition,
                 minTime,
                 maxTime);
     }

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1009,17 +1009,32 @@ body[data-theme='light'] .highlight-item {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 1rem 1.25rem;
+  padding: 2.5rem 1.25rem 1rem 1.25rem;
   border-radius: 16px;
   background: var(--surface-dark-soft);
   border: 1px solid var(--border-dark);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  position: relative;
 }
 
 body[data-theme='light'] .highlight-metric {
   background: var(--surface-light-soft);
   border-color: var(--border-light);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.rank-badge {
+  width: 2.75rem;
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+.highlight-rank-badge {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 3rem;
 }
 
 .highlight-metric-label {
@@ -1290,11 +1305,12 @@ body[data-theme='light'] .leaderboard-chart {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1.25rem 1.5rem;
+  padding: 1.25rem 1.5rem 3.25rem 1.5rem;
   border-radius: 18px;
   background: var(--surface-dark);
   box-shadow: var(--shadow-elevated);
   border: 1px solid var(--border-dark);
+  position: relative;
 }
 
 body[data-theme='light'] .leaderboard-run {
@@ -1336,6 +1352,13 @@ body[data-theme='light'] .leaderboard-run {
 .leaderboard-mutation-icons {
   align-self: flex-end;
   margin-top: auto;
+}
+
+.leaderboard-rank-badge {
+  position: absolute;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  width: 3rem;
 }
 
 .leaderboard-player {
@@ -1782,6 +1805,8 @@ body[data-theme='light'] .player-dungeon-card {
 .player-dungeon-stat {
   display: grid;
   gap: 0.35rem;
+  position: relative;
+  padding-top: 2.75rem;
 }
 
 .player-dungeon-stat dt {
@@ -1813,10 +1838,18 @@ body[data-theme='light'] .player-dungeon-card {
 .player-dungeon-week {
   font-size: 0.85rem;
   opacity: 0.75;
+  flex-basis: 100%;
 }
 
 .player-dungeon-empty {
   opacity: 0.65;
+}
+
+.player-rank-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 3rem;
 }
 
 .leaderboard-status {

--- a/nwleaderboard-ui/js/components/RankBadge.js
+++ b/nwleaderboard-ui/js/components/RankBadge.js
@@ -1,0 +1,35 @@
+const MAX_ICON_POSITION = 9;
+
+function normalisePosition(position) {
+  if (position === undefined || position === null) {
+    return null;
+  }
+  const numeric = Number(position);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  const integer = Math.floor(Math.max(1, numeric));
+  if (integer < 1 || integer > MAX_ICON_POSITION) {
+    return null;
+  }
+  return integer;
+}
+
+export default function RankBadge({ position, label, className = '' }) {
+  const normalised = normalisePosition(position);
+  if (!normalised) {
+    return null;
+  }
+  const src = `/images/icons/top/top_${normalised}.png`;
+  const alt = label ? `${label} ${normalised}` : `Top ${normalised}`;
+  const combinedClassName = className ? `rank-badge ${className}` : 'rank-badge';
+  return (
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      className={combinedClassName}
+    />
+  );
+}

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -1,6 +1,7 @@
 import { LangContext } from '../i18n.js';
 import DungeonIcon from '../components/DungeonIcon.js';
 import MutationIconList from '../components/MutationIconList.js';
+import RankBadge from '../components/RankBadge.js';
 import {
   deriveFallbackName,
   getDungeonNameForLang,
@@ -60,9 +61,13 @@ function normaliseMetric(metric) {
   const week = metric.week ?? metric.period ?? metric.season ?? null;
   const players = normalisePlayers(metric.players);
   const mutations = extractMutationIds(metric);
+  const position = toPositiveInteger(
+    metric.position ?? metric.rank ?? metric.place ?? metric.standing ?? metric.pos,
+  );
   return {
     value: Number.isFinite(value) ? value : toPositiveInteger(value),
     week: toPositiveInteger(week),
+    position,
     players,
     mutations,
   };
@@ -223,6 +228,11 @@ export default function Home() {
                   </header>
                   <div className="highlight-metrics">
                     <div className="highlight-metric">
+                      <RankBadge
+                        position={score?.position}
+                        label={t.highlightScoreLabel ?? t.playerBestScore}
+                        className="highlight-rank-badge"
+                      />
                       <span className="highlight-metric-label">{t.highlightScoreLabel ?? t.playerBestScore}</span>
                       <span className="highlight-metric-value">{scoreValue}</span>
                       {scoreWeek ? (
@@ -257,6 +267,11 @@ export default function Home() {
                       />
                     </div>
                     <div className="highlight-metric">
+                      <RankBadge
+                        position={time?.position}
+                        label={t.highlightTimeLabel ?? t.playerBestTime}
+                        className="highlight-rank-badge"
+                      />
                       <span className="highlight-metric-label">{t.highlightTimeLabel ?? t.playerBestTime}</span>
                       <span className="highlight-metric-value">{timeValue}</span>
                       {timeWeek ? (

--- a/nwleaderboard-ui/js/pages/LeaderboardPage.js
+++ b/nwleaderboard-ui/js/pages/LeaderboardPage.js
@@ -2,6 +2,7 @@ import { LangContext } from '../i18n.js';
 import ChartCanvas from '../components/ChartCanvas.js';
 import DungeonIcon from '../components/DungeonIcon.js';
 import MutationIconList from '../components/MutationIconList.js';
+import RankBadge from '../components/RankBadge.js';
 import { getDungeonNameForLang, normaliseDungeons, sortDungeons } from '../dungeons.js';
 import { extractMutationIds } from '../mutations.js';
 import { capitaliseWords } from '../text.js';
@@ -197,12 +198,15 @@ export default function LeaderboardPage({
           const value = getValue(entry);
           const players = normalisePlayers(entry);
           const week = deriveWeek(entry);
+          const position =
+            entry?.position ?? entry?.rank ?? entry?.place ?? entry?.standing ?? entry?.pos ?? null;
           const id = entry?.id ?? entry?.entryId ?? `${week || 'entry'}-${index}`;
           return {
             id: String(id),
             week: week ? String(week) : '',
             players,
             value,
+            position,
             raw: entry,
           };
         });
@@ -570,6 +574,11 @@ export default function LeaderboardPage({
                   const mutations = extractMutationIds(entry.raw);
                   return (
                     <li key={entry.id} className="leaderboard-run">
+                      <RankBadge
+                        position={entry.position ?? entry.raw?.position}
+                        label={t.individualRankHeader}
+                        className="leaderboard-rank-badge"
+                      />
                       <div className="leaderboard-run-header">
                         <span className="leaderboard-week">{weekDisplay}</span>
                         <span className="leaderboard-value">{valueDisplay}</span>

--- a/nwleaderboard-ui/js/pages/Player.js
+++ b/nwleaderboard-ui/js/pages/Player.js
@@ -3,6 +3,7 @@ import { getDungeonIconPath, getDungeonNameForLang, sortDungeons } from '../dung
 import ChartCanvas from '../components/ChartCanvas.js';
 import DungeonIcon from '../components/DungeonIcon.js';
 import MutationIconList from '../components/MutationIconList.js';
+import RankBadge from '../components/RankBadge.js';
 import { capitaliseWords } from '../text.js';
 import { extractMutationIds } from '../mutations.js';
 
@@ -301,10 +302,12 @@ export default function Player() {
       fallbackName: entry?.fallbackName || '',
       bestScore: entry?.bestScore ?? null,
       bestScoreWeek: entry?.bestScoreWeek ?? null,
+      bestScorePosition: entry?.bestScorePosition ?? entry?.best_score_position ?? null,
       minScore: entry?.minScore ?? null,
       maxScore: entry?.maxScore ?? null,
       bestTime: entry?.bestTime ?? null,
       bestTimeWeek: entry?.bestTimeWeek ?? null,
+      bestTimePosition: entry?.bestTimePosition ?? entry?.best_time_position ?? null,
       minTime: entry?.minTime ?? null,
       maxTime: entry?.maxTime ?? null,
       scoreMutations: extractMutationIds(
@@ -724,6 +727,11 @@ export default function Player() {
                     </h2>
                     <dl className="player-dungeon-stats">
                       <div className="player-dungeon-stat">
+                        <RankBadge
+                          position={dungeon.bestScorePosition}
+                          label={t.playerBestScore}
+                          className="player-rank-badge"
+                        />
                         <dt>{t.playerBestScore}</dt>
                         <dd>
                           {hasScore ? (
@@ -743,6 +751,11 @@ export default function Player() {
                         </dd>
                       </div>
                       <div className="player-dungeon-stat">
+                        <RankBadge
+                          position={dungeon.bestTimePosition}
+                          label={t.playerBestTime}
+                          className="player-rank-badge"
+                        />
                         <dt>{t.playerBestTime}</dt>
                         <dd>
                           {hasTime ? (


### PR DESCRIPTION
## Summary
- expose leaderboard entry positions across highlights, leaderboard listings, and player profiles
- compute placement using new repository helpers for score and time runs
- surface the rank icons in the web UI with updated styling for highlights, leaderboards, and player records

## Testing
- mvn test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7abfc481c832cbfd0d9b78795c2d7