### PR TITLE
Remove background and border styles from form containers

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -441,12 +441,10 @@ body[data-theme='light'] .site-footer {
 
 .form,
 .highlight-list {
-  background: var(--surface-dark);
   border-radius: 18px;
   padding: 1.5rem;
   box-shadow: var(--shadow-elevated);
   backdrop-filter: blur(16px);
-  border: 1px solid var(--border-dark);
 }
 
 body[data-theme='light'] .form,


### PR DESCRIPTION
## Summary
- remove the shared background color from the `.form` and `.highlight-list` components
- drop the dark theme border so the containers render without an outline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7cc8c569c832cb7c8c66939e2bfcc