### PR TITLE
Tint mutation icons purple

### DIFF
--- a/nwleaderboard-ui/js/components/MutationIconList.js
+++ b/nwleaderboard-ui/js/components/MutationIconList.js
@@ -1,16 +1,110 @@
 import { getMutationIconSources } from '../mutations.js';
 
+const MUTATION_ICON_COLOR = { r: 0x4f, g: 0x11, b: 0x82 };
+const tintedIconCache = new Map();
+
+async function tintMutationIcon(src) {
+  if (tintedIconCache.has(src)) {
+    return tintedIconCache.get(src);
+  }
+
+  if (typeof window === 'undefined' || typeof Image === 'undefined') {
+    return src;
+  }
+
+  const image = new Image();
+  image.decoding = 'async';
+  image.crossOrigin = 'anonymous';
+
+  const tintedSource = await new Promise((resolve, reject) => {
+    image.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = image.naturalWidth || image.width;
+        canvas.height = image.naturalHeight || image.height;
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+          reject(new Error('Canvas context not available'));
+          return;
+        }
+
+        context.drawImage(image, 0, 0);
+        const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+        const { data } = imageData;
+
+        for (let index = 0; index < data.length; index += 4) {
+          const alpha = data[index + 3];
+          if (alpha === 0) {
+            continue;
+          }
+
+          const intensity = data[index] / 255;
+          const factor = 1 - intensity;
+
+          data[index] = Math.round(MUTATION_ICON_COLOR.r * factor);
+          data[index + 1] = Math.round(MUTATION_ICON_COLOR.g * factor);
+          data[index + 2] = Math.round(MUTATION_ICON_COLOR.b * factor);
+        }
+
+        context.putImageData(imageData, 0, 0);
+        resolve(canvas.toDataURL());
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    image.onerror = () => {
+      reject(new Error(`Unable to load mutation icon: ${src}`));
+    };
+
+    image.src = src;
+  });
+
+  tintedIconCache.set(src, tintedSource);
+  return tintedSource;
+}
+
 function MutationIcon({ src }) {
   const [hidden, setHidden] = React.useState(false);
+  const [tintedSrc, setTintedSrc] = React.useState(null);
 
-  if (!src || hidden) {
+  React.useEffect(() => {
+    let isCancelled = false;
+
+    if (!src) {
+      setTintedSrc(null);
+      return undefined;
+    }
+
+    setHidden(false);
+    setTintedSrc(null);
+
+    tintMutationIcon(src)
+      .then((result) => {
+        if (!isCancelled) {
+          setTintedSrc(result);
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setHidden(true);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [src]);
+
+  if (!src || hidden || !tintedSrc) {
     return null;
   }
 
   return (
     <li className="mutation-icon-item">
       <img
-        src={src}
+        src={tintedSrc}
         alt=""
         aria-hidden="true"
         className="mutation-icon"


### PR DESCRIPTION
## Summary
- recolor mutation icon images in the browser by tinting them to #4F1182 via canvas processing
- cache tinted results to avoid redundant image work and handle loading errors gracefully

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d81e9311f4832cabc61cc9f03d5cc3