### PR TITLE
Add suggestion submission endpoints and UI

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/SuggestionResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/SuggestionResource.java
@@ -1,0 +1,199 @@
+package com.opyruso.nwleaderboard;
+
+import com.opyruso.nwleaderboard.dto.ApiMessageResponse;
+import com.opyruso.nwleaderboard.dto.SuggestionRequest;
+import com.opyruso.nwleaderboard.dto.SuggestionResponse;
+import com.opyruso.nwleaderboard.dto.SuggestionStatusUpdateRequest;
+import com.opyruso.nwleaderboard.entity.Suggestion;
+import com.opyruso.nwleaderboard.entity.SuggestionStatus;
+import com.opyruso.nwleaderboard.service.SuggestionService;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.logging.Logger;
+
+/**
+ * REST resource exposing CRUD operations for user suggestions.
+ */
+@Path("/suggestions")
+@Authenticated
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class SuggestionResource {
+
+    private static final Logger LOG = Logger.getLogger(SuggestionResource.class);
+
+    @Inject
+    SuggestionService suggestionService;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    JsonWebToken jwt;
+
+    @POST
+    public Response createSuggestion(@Valid SuggestionRequest request) {
+        try {
+            String author = currentUserId();
+            String title = request.title().trim();
+            String content = request.content().trim();
+            Suggestion suggestion = suggestionService.createSuggestion(author, title, content);
+            SuggestionResponse response = toResponse(suggestion, false, true);
+            return Response.status(Status.CREATED).entity(response).build();
+        } catch (IllegalStateException e) {
+            LOG.error("Unable to identify current user for suggestion creation", e);
+            return Response.status(Status.UNAUTHORIZED)
+                    .entity(new ApiMessageResponse("Authentication required", null))
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Unable to store user suggestion", e);
+            return Response.status(Status.BAD_GATEWAY)
+                    .entity(new ApiMessageResponse("Unable to store suggestion", null))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/mine")
+    public Response listCurrentUserSuggestions() {
+        try {
+            String author = currentUserId();
+            List<SuggestionResponse> suggestions = suggestionService.listForAuthor(author).stream()
+                    .map(entity -> toResponse(entity, false, false))
+                    .collect(Collectors.toList());
+            return Response.ok(suggestions).build();
+        } catch (IllegalStateException e) {
+            LOG.error("Unable to identify current user while listing suggestions", e);
+            return Response.status(Status.UNAUTHORIZED)
+                    .entity(new ApiMessageResponse("Authentication required", null))
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Unable to list user suggestions", e);
+            return Response.status(Status.BAD_GATEWAY)
+                    .entity(new ApiMessageResponse("Unable to list suggestions", null))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/admin")
+    public Response listAllSuggestions() {
+        if (!hasAdminRole()) {
+            return Response.status(Status.FORBIDDEN)
+                    .entity(new ApiMessageResponse("Admin role required", null))
+                    .build();
+        }
+        try {
+            List<SuggestionResponse> suggestions = suggestionService.listAll().stream()
+                    .map(entity -> toResponse(entity, true, true))
+                    .collect(Collectors.toList());
+            return Response.ok(suggestions).build();
+        } catch (Exception e) {
+            LOG.error("Unable to list suggestions", e);
+            return Response.status(Status.BAD_GATEWAY)
+                    .entity(new ApiMessageResponse("Unable to list suggestions", null))
+                    .build();
+        }
+    }
+
+    @PUT
+    @Path("/{id}/status")
+    public Response updateStatus(@PathParam("id") Long id, @Valid SuggestionStatusUpdateRequest request) {
+        if (!hasAdminRole()) {
+            return Response.status(Status.FORBIDDEN)
+                    .entity(new ApiMessageResponse("Admin role required", null))
+                    .build();
+        }
+        SuggestionStatus status = SuggestionStatus.fromString(request.status());
+        if (status == null) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity(new ApiMessageResponse("Unknown status", null))
+                    .build();
+        }
+        try {
+            return suggestionService.updateStatus(id, status)
+                    .map(entity -> Response.ok(toResponse(entity, true, true)).build())
+                    .orElseGet(() -> Response.status(Status.NOT_FOUND)
+                            .entity(new ApiMessageResponse("Suggestion not found", null))
+                            .build());
+        } catch (Exception e) {
+            LOG.error("Unable to update suggestion status", e);
+            return Response.status(Status.BAD_GATEWAY)
+                    .entity(new ApiMessageResponse("Unable to update suggestion status", null))
+                    .build();
+        }
+    }
+
+    private String currentUserId() {
+        if (jwt != null && jwt.getSubject() != null && !jwt.getSubject().isBlank()) {
+            return jwt.getSubject();
+        }
+        if (identity != null && identity.getPrincipal() != null) {
+            String name = identity.getPrincipal().getName();
+            if (name != null && !name.isBlank()) {
+                return name;
+            }
+        }
+        throw new IllegalStateException("Unable to identify current user");
+    }
+
+    private boolean hasAdminRole() {
+        if (identity != null && !identity.isAnonymous() && identity.getRoles().contains("admin")) {
+            return true;
+        }
+        if (jwt != null) {
+            Set<String> groups = jwt.getGroups();
+            if (groups != null && groups.stream().anyMatch(role -> "admin".equalsIgnoreCase(role))) {
+                return true;
+            }
+            Object resourceAccessClaim = jwt.getClaim("resource_access");
+            if (resourceAccessClaim instanceof Map<?, ?> resourceAccess) {
+                Object client = resourceAccess.get("nwleaderboard-app");
+                if (client instanceof Map<?, ?> clientData) {
+                    Object rolesObject = clientData.get("roles");
+                    if (rolesObject instanceof Iterable<?> roles) {
+                        for (Object role : roles) {
+                            if (role != null && "admin".equalsIgnoreCase(role.toString())) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private SuggestionResponse toResponse(Suggestion entity, boolean includeAuthor, boolean includeContent) {
+        if (entity == null) {
+            return null;
+        }
+        String author = includeAuthor ? entity.getAuthor() : null;
+        String content = includeContent ? entity.getContent() : null;
+        String createdAt = formatDate(entity.getCreationDate());
+        return new SuggestionResponse(entity.getId(), author, entity.getTitle(), content,
+                entity.getStatus() != null ? entity.getStatus().name() : null, createdAt);
+    }
+
+    private String formatDate(LocalDateTime dateTime) {
+        return dateTime != null ? dateTime.toString() : null;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SuggestionRequest.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SuggestionRequest.java
@@ -1,0 +1,13 @@
+package com.opyruso.nwleaderboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request payload to create a new suggestion.
+ */
+public record SuggestionRequest(
+        @JsonProperty("title") @NotBlank @Size(max = 200) String title,
+        @JsonProperty("content") @NotBlank @Size(max = 5000) String content) {
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SuggestionResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SuggestionResponse.java
@@ -1,0 +1,17 @@
+package com.opyruso.nwleaderboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Description of a suggestion sent back to clients.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SuggestionResponse(
+        @JsonProperty("id") Long id,
+        @JsonProperty("author") String author,
+        @JsonProperty("title") String title,
+        @JsonProperty("content") String content,
+        @JsonProperty("status") String status,
+        @JsonProperty("created_at") String createdAt) {
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SuggestionStatusUpdateRequest.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SuggestionStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.opyruso.nwleaderboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request payload to update the status of an existing suggestion.
+ */
+public record SuggestionStatusUpdateRequest(
+        @JsonProperty("status") @NotBlank String status) {
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Suggestion.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Suggestion.java
@@ -1,0 +1,77 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+/**
+ * Suggestion or bug report submitted by an authenticated user.
+ */
+@Entity
+@Table(name = "suggestion")
+public class Suggestion extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "author", nullable = false, length = 64)
+    private String author;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private SuggestionStatus status = SuggestionStatus.NEW;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public SuggestionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SuggestionStatus status) {
+        this.status = status;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/SuggestionStatus.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/SuggestionStatus.java
@@ -1,0 +1,24 @@
+package com.opyruso.nwleaderboard.entity;
+
+/**
+ * Possible statuses for a user suggestion.
+ */
+public enum SuggestionStatus {
+    NEW,
+    IN_PROGRESS,
+    PUT_ON_TODO_LIST,
+    REFUSED,
+    FIXED;
+
+    public static SuggestionStatus fromString(String value) {
+        if (value == null) {
+            return null;
+        }
+        for (SuggestionStatus status : values()) {
+            if (status.name().equalsIgnoreCase(value.trim())) {
+                return status;
+            }
+        }
+        return null;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/SuggestionRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/SuggestionRepository.java
@@ -1,0 +1,22 @@
+package com.opyruso.nwleaderboard.repository;
+
+import com.opyruso.nwleaderboard.entity.Suggestion;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Repository handling persistence for {@link Suggestion} entities.
+ */
+@ApplicationScoped
+public class SuggestionRepository implements PanacheRepository<Suggestion> {
+
+    public List<Suggestion> listByAuthor(String author) {
+        return list("author", Sort.by("creationDate").descending(), author);
+    }
+
+    public List<Suggestion> listAllOldestFirst() {
+        return list("order by creationDate asc");
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/SuggestionService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/SuggestionService.java
@@ -1,0 +1,52 @@
+package com.opyruso.nwleaderboard.service;
+
+import com.opyruso.nwleaderboard.entity.Suggestion;
+import com.opyruso.nwleaderboard.entity.SuggestionStatus;
+import com.opyruso.nwleaderboard.repository.SuggestionRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Business service handling suggestion persistence and retrieval.
+ */
+@ApplicationScoped
+public class SuggestionService {
+
+    @Inject
+    SuggestionRepository suggestionRepository;
+
+    @Transactional
+    public Suggestion createSuggestion(String author, String title, String content) {
+        Suggestion suggestion = new Suggestion();
+        suggestion.setAuthor(author);
+        suggestion.setTitle(title);
+        suggestion.setContent(content);
+        suggestion.setStatus(SuggestionStatus.NEW);
+        suggestionRepository.persist(suggestion);
+        suggestionRepository.flush();
+        return suggestion;
+    }
+
+    public List<Suggestion> listForAuthor(String author) {
+        return suggestionRepository.listByAuthor(author);
+    }
+
+    public List<Suggestion> listAll() {
+        return suggestionRepository.listAllOldestFirst();
+    }
+
+    @Transactional
+    public Optional<Suggestion> updateStatus(Long id, SuggestionStatus status) {
+        if (id == null || status == null) {
+            return Optional.empty();
+        }
+        return suggestionRepository.findByIdOptional(id).map(entity -> {
+            entity.setStatus(status);
+            suggestionRepository.flush();
+            return entity;
+        });
+    }
+}

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -322,7 +322,7 @@ body[data-theme='light'] .site-nav__dropdown-menu {
   bottom: 0;
   z-index: 900;
   padding: clamp(1.35rem, 3vw, 1.85rem) clamp(1rem, 4vw, 1.75rem);
-  text-align: center;
+  text-align: initial;
   font-size: clamp(0.8rem, 1.2vw, 0.95rem);
   color: rgba(248, 250, 252, 0.72);
   background: rgba(5, 8, 22, 0.7);
@@ -332,7 +332,7 @@ body[data-theme='light'] .site-nav__dropdown-menu {
 
 .site-footer__content {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.65rem;
 }
@@ -340,11 +340,17 @@ body[data-theme='light'] .site-nav__dropdown-menu {
 .site-footer__links {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 0.9rem;
   margin: 0;
   padding: 0;
   list-style: none;
+  flex: 1 1 auto;
+  margin-left: auto;
+}
+
+.site-footer__content > small {
+  flex: 1 1 auto;
 }
 
 .site-footer__link {

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -330,10 +330,46 @@ body[data-theme='light'] .site-nav__dropdown-menu {
   backdrop-filter: blur(16px);
 }
 
+.site-footer__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.site-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-footer__link {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.site-footer__link:hover,
+.site-footer__link:focus-visible {
+  border-bottom-color: currentColor;
+  color: var(--color-foreground-dark);
+}
+
 body[data-theme='light'] .site-footer {
   color: rgba(16, 23, 42, 0.72);
   background: rgba(246, 248, 255, 0.88);
   border-top-color: var(--border-light);
+}
+
+body[data-theme='light'] .site-footer__link:hover,
+body[data-theme='light'] .site-footer__link:focus-visible {
+  color: var(--color-foreground-light);
 }
 
 @media (max-width: 960px) {
@@ -477,7 +513,8 @@ body[data-theme='light'] .highlight-list {
 }
 
 .form-field input,
-.form-field select {
+.form-field select,
+.form-field textarea {
   padding: 0.75rem 1rem;
   border-radius: 12px;
   border: 1px solid var(--border-dark);
@@ -493,20 +530,27 @@ body[data-theme='light'] .highlight-list {
 }
 
 .form-field input:focus,
-.form-field select:focus {
+.form-field select:focus,
+.form-field textarea:focus {
   outline: none;
   border-color: rgba(124, 92, 255, 0.75);
   box-shadow: 0 0 0 2px rgba(124, 92, 255, 0.25);
 }
 
 body[data-theme='light'] .form-field input,
-body[data-theme='light'] .form-field select {
+body[data-theme='light'] .form-field select,
+body[data-theme='light'] .form-field textarea {
   background: rgba(255, 255, 255, 0.92);
   border-color: var(--border-light);
 }
 
 .form-field select {
   cursor: pointer;
+}
+
+.form-field textarea {
+  min-height: 12rem;
+  resize: vertical;
 }
 
 .form-field-floating span {
@@ -931,6 +975,125 @@ body[data-theme='light'] .contribute-dungeon-checkbox.active {
 
 .form-footer {
   margin-top: 1.5rem;
+}
+
+.suggestion-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.suggestion-form {
+  margin-bottom: 0;
+}
+
+.suggestion-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.suggestion-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.suggestion-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.suggestion-item__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.suggestion-item__summary {
+  flex: 1 1 auto;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.suggestion-item__summary:focus-visible {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 4px;
+}
+
+.suggestion-item__title {
+  font-weight: 600;
+  font-size: clamp(1.1rem, 2.2vw, 1.35rem);
+}
+
+.suggestion-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+.suggestion-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.22);
+  font-size: 0.85rem;
+  letter-spacing: 0.5px;
+}
+
+.suggestion-item__status {
+  flex: 0 1 220px;
+  min-width: 200px;
+}
+
+.suggestion-item__details {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding-top: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.suggestion-item__author {
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.suggestion-item__content {
+  margin: 0;
+  white-space: pre-line;
+  line-height: 1.6;
+}
+
+.suggestion-message {
+  margin: 0;
+  font-size: 1.05rem;
+  opacity: 0.85;
+}
+
+body[data-theme='light'] .suggestion-status-badge {
+  background: rgba(124, 92, 255, 0.12);
+}
+
+body[data-theme='light'] .suggestion-item__details {
+  border-top-color: rgba(148, 163, 184, 0.35);
 }
 
 .highlight-section {

--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -15,6 +15,7 @@ import ContributeStats from './pages/ContributeStats.js';
 import ContributePlayers from './pages/ContributePlayers.js';
 import ContributeValidate from './pages/ContributeValidate.js';
 import Player from './pages/Player.js';
+import Suggestions from './pages/Suggestions.js';
 import VersionChecker from './VersionChecker.js';
 import Header from './Header.js';
 import Footer from './Footer.js';
@@ -26,6 +27,7 @@ import {
   stopTokenRefresh,
   getStoredTokens,
   hasContributorRole,
+  hasAdminRole,
 } from './auth.js';
 
 const { BrowserRouter, Routes, Route, Navigate } = ReactRouterDOM;
@@ -36,11 +38,12 @@ export default function App() {
     return {
       token: stored && stored.access_token ? stored.access_token : null,
       canContribute: hasContributorRole(stored),
+      isAdmin: hasAdminRole(stored),
     };
   });
 
   const handleLogout = React.useCallback(() => {
-    setAuthState({ token: null, canContribute: false });
+    setAuthState({ token: null, canContribute: false, isAdmin: false });
     clearTokens();
     stopTokenRefresh();
   }, []);
@@ -63,6 +66,7 @@ export default function App() {
     setAuthState({
       token: tokens && tokens.access_token ? tokens.access_token : null,
       canContribute: hasContributorRole(tokens),
+      isAdmin: hasAdminRole(tokens),
     });
   };
 
@@ -125,6 +129,16 @@ export default function App() {
                 <Route path="players" element={<ContributePlayers />} />
                 <Route path="*" element={<Navigate to="." replace />} />
               </Route>
+              <Route
+                path="/suggestions"
+                element={
+                  authenticated ? (
+                    <Suggestions isAdmin={authState.isAdmin} />
+                  ) : (
+                    <Navigate to="/login" replace />
+                  )
+                }
+              />
               <Route path="/player/:playerId?" element={<Player canContribute={authState.canContribute} />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>

--- a/nwleaderboard-ui/js/Footer.js
+++ b/nwleaderboard-ui/js/Footer.js
@@ -1,3 +1,5 @@
+const { Link } = ReactRouterDOM;
+
 export default function Footer() {
   const currentYear = new Date().getFullYear();
   const footerRef = React.useRef(null);
@@ -33,7 +35,14 @@ export default function Footer() {
 
   return (
     <footer ref={footerRef} className="site-footer">
-      <small>oPyRuSo (TM) 2025 - {currentYear}</small>
+      <div className="site-footer__content">
+        <small>oPyRuSo (TM) 2025 - {currentYear}</small>
+        <nav className="site-footer__links" aria-label="Footer links">
+          <Link className="site-footer__link" to="/suggestions">
+            Bug / Suggestion
+          </Link>
+        </nav>
+      </div>
     </footer>
   );
 }

--- a/nwleaderboard-ui/js/auth.js
+++ b/nwleaderboard-ui/js/auth.js
@@ -167,6 +167,22 @@ export function hasContributorRole(tokens) {
   return hasClientRole(payload, 'nwleaderboard-app', 'contributor');
 }
 
+export function hasAdminRole(tokens) {
+  const source = tokens || readStoredTokens();
+  if (!source || !source.access_token) {
+    return false;
+  }
+  const payload = decodeAccessToken(source.access_token);
+  if (!payload) {
+    return false;
+  }
+  const roles = collectRolesFromPayload(payload);
+  if (roles.some((role) => role.toLowerCase() === 'admin')) {
+    return true;
+  }
+  return hasClientRole(payload, 'nwleaderboard-app', 'admin');
+}
+
 export function setupAuthFetch() {
   if (fetchInitialised) return;
   fetchInitialised = true;

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -313,6 +313,31 @@ const en = {
   cacheComplete: 'Offline cache ready',
   cacheSummary: (success, total) =>
     `${success}/${total} assets cached for offline usage`,
+  suggestionsTitle: 'Bug reports & suggestions',
+  suggestionsDescription: 'Report a bug or share an idea for the leaderboard.',
+  suggestionsAdminDescription: 'Review and update all suggestions sent by players.',
+  suggestionsFormTitle: 'Title',
+  suggestionsFormContent: 'Description',
+  suggestionsFormSubmit: 'Send suggestion',
+  suggestionsFormSuccess: 'Suggestion submitted. Thank you!',
+  suggestionsFormError: 'Unable to submit your suggestion. Please try again later.',
+  suggestionsListTitle: 'Your suggestions',
+  suggestionsAdminListTitle: 'All suggestions',
+  suggestionsListEmpty: 'You have not submitted any suggestion yet.',
+  suggestionsAdminEmpty: 'No suggestion has been submitted yet.',
+  suggestionsLoading: 'Loading suggestions…',
+  suggestionsLoadError: 'Unable to load the suggestions.',
+  suggestionsStatusUpdateSuccess: 'Suggestion status updated.',
+  suggestionsStatusUpdateError: 'Unable to update the suggestion status.',
+  suggestionsStatus: {
+    NEW: 'New',
+    IN_PROGRESS: 'In progress',
+    PUT_ON_TODO_LIST: 'To-do list',
+    REFUSED: 'Refused',
+    FIXED: 'Fixed',
+  },
+  suggestionsAdminStatusLabel: 'Status',
+  suggestionsAdminAuthor: (author) => `Author: ${author}`,
 };
 
 export default en;

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -320,6 +320,31 @@ const fr = {
   cacheComplete: 'Cache hors-ligne prêt',
   cacheSummary: (success, total) =>
     `${success}/${total} ressources en cache pour une utilisation hors-ligne`,
+  suggestionsTitle: 'Bugs & suggestions',
+  suggestionsDescription: 'Signalez un bug ou proposez une amélioration pour le site.',
+  suggestionsAdminDescription: 'Consultez et mettez à jour toutes les suggestions envoyées.',
+  suggestionsFormTitle: 'Titre',
+  suggestionsFormContent: 'Description',
+  suggestionsFormSubmit: 'Envoyer',
+  suggestionsFormSuccess: 'Suggestion envoyée. Merci !',
+  suggestionsFormError: 'Impossible d’envoyer votre suggestion. Réessayez plus tard.',
+  suggestionsListTitle: 'Vos suggestions',
+  suggestionsAdminListTitle: 'Toutes les suggestions',
+  suggestionsListEmpty: 'Vous n’avez pas encore envoyé de suggestion.',
+  suggestionsAdminEmpty: 'Aucune suggestion n’a été envoyée pour le moment.',
+  suggestionsLoading: 'Chargement des suggestions…',
+  suggestionsLoadError: 'Impossible de charger les suggestions.',
+  suggestionsStatusUpdateSuccess: 'Statut de la suggestion mis à jour.',
+  suggestionsStatusUpdateError: 'Impossible de mettre à jour le statut de la suggestion.',
+  suggestionsStatus: {
+    NEW: 'Nouvelle',
+    IN_PROGRESS: 'En cours',
+    PUT_ON_TODO_LIST: 'À faire',
+    REFUSED: 'Refusée',
+    FIXED: 'Résolue',
+  },
+  suggestionsAdminStatusLabel: 'Statut',
+  suggestionsAdminAuthor: (author) => `Auteur : ${author}`,
 };
 
 export default fr;

--- a/nwleaderboard-ui/js/pages/Suggestions.js
+++ b/nwleaderboard-ui/js/pages/Suggestions.js
@@ -1,0 +1,274 @@
+import { LangContext } from '../i18n.js';
+
+const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
+const SUGGESTION_STATUSES = [
+  'NEW',
+  'IN_PROGRESS',
+  'PUT_ON_TODO_LIST',
+  'REFUSED',
+  'FIXED',
+];
+
+export default function Suggestions({ isAdmin }) {
+  const { t, lang } = React.useContext(LangContext);
+  const [form, setForm] = React.useState({ title: '', content: '' });
+  const [submitState, setSubmitState] = React.useState('idle');
+  const [feedback, setFeedback] = React.useState({ type: '', message: '' });
+  const [suggestions, setSuggestions] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  const [loadError, setLoadError] = React.useState('');
+  const [expandedId, setExpandedId] = React.useState(null);
+  const [updatingId, setUpdatingId] = React.useState(null);
+
+  const statusLabels = t.suggestionsStatus || {};
+
+  const locale = lang === 'esmx' ? 'es-MX' : lang || 'en';
+
+  const formatDate = React.useCallback(
+    (value) => {
+      if (!value) {
+        return '';
+      }
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return value;
+      }
+      try {
+        return new Intl.DateTimeFormat(locale, {
+          dateStyle: 'short',
+          timeStyle: 'short',
+        }).format(date);
+      } catch (error) {
+        return date.toLocaleString();
+      }
+    },
+    [locale]
+  );
+
+  const fetchSuggestions = React.useCallback(async () => {
+    if (!API_BASE_URL) {
+      setSuggestions([]);
+      setLoading(false);
+      setLoadError(t.suggestionsLoadError);
+      return;
+    }
+    setLoading(true);
+    setLoadError('');
+    try {
+      const endpoint = isAdmin ? '/suggestions/admin' : '/suggestions/mine';
+      const response = await fetch(`${API_BASE_URL}${endpoint}`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const payload = await response.json();
+      setSuggestions(Array.isArray(payload) ? payload : []);
+    } catch (error) {
+      console.warn('Unable to load suggestions', error);
+      setLoadError(t.suggestionsLoadError);
+      setSuggestions([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [isAdmin, t]);
+
+  React.useEffect(() => {
+    fetchSuggestions();
+  }, [fetchSuggestions]);
+
+  const updateField = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const resetFeedback = () => setFeedback({ type: '', message: '' });
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (isAdmin) {
+      return;
+    }
+    resetFeedback();
+    if (!API_BASE_URL) {
+      setFeedback({ type: 'error', message: t.suggestionsFormError });
+      return;
+    }
+    setSubmitState('loading');
+    try {
+      const response = await fetch(`${API_BASE_URL}/suggestions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: form.title.trim(),
+          content: form.content.trim(),
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      setFeedback({ type: 'success', message: t.suggestionsFormSuccess });
+      setForm({ title: '', content: '' });
+      fetchSuggestions();
+    } catch (error) {
+      console.warn('Unable to submit suggestion', error);
+      setFeedback({ type: 'error', message: t.suggestionsFormError });
+    } finally {
+      setSubmitState('idle');
+    }
+  };
+
+  const handleStatusChange = async (id, nextStatus) => {
+    if (!isAdmin || !nextStatus || updatingId === id) {
+      return;
+    }
+    resetFeedback();
+    setUpdatingId(id);
+    try {
+      const response = await fetch(`${API_BASE_URL}/suggestions/${id}/status`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: nextStatus }),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      setFeedback({ type: 'success', message: t.suggestionsStatusUpdateSuccess });
+      fetchSuggestions();
+    } catch (error) {
+      console.warn('Unable to update suggestion status', error);
+      setFeedback({ type: 'error', message: t.suggestionsStatusUpdateError });
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  const toggleExpanded = (id) => {
+    setExpandedId((current) => (current === id ? null : id));
+  };
+
+  const renderStatusLabel = (status) => statusLabels[status] || status;
+
+  const renderList = () => {
+    if (loading) {
+      return <p className="suggestion-message">{t.suggestionsLoading}</p>;
+    }
+    if (loadError) {
+      return <p className="form-message error">{loadError}</p>;
+    }
+    if (!suggestions.length) {
+      return (
+        <p className="suggestion-message">
+          {isAdmin ? t.suggestionsAdminEmpty : t.suggestionsListEmpty}
+        </p>
+      );
+    }
+    return (
+      <ul className="suggestion-list">
+        {suggestions.map((item) => {
+          const createdAt = formatDate(item.created_at);
+          const expanded = expandedId === item.id;
+          return (
+            <li key={item.id} className="form suggestion-card">
+              <div className="suggestion-item__row">
+                <button
+                  type="button"
+                  className="suggestion-item__summary"
+                  onClick={() => toggleExpanded(item.id)}
+                >
+                  <span className="suggestion-item__title">{item.title}</span>
+                  <span className="suggestion-item__meta">
+                    {createdAt ? <span>{createdAt}</span> : null}
+                    <span className="suggestion-status-badge">
+                      {renderStatusLabel(item.status)}
+                    </span>
+                  </span>
+                </button>
+                {isAdmin ? (
+                  <label className="form-field suggestion-item__status" onClick={(event) => event.stopPropagation()}>
+                    <span>{t.suggestionsAdminStatusLabel}</span>
+                    <select
+                      value={item.status}
+                      onChange={(event) => handleStatusChange(item.id, event.target.value)}
+                      disabled={updatingId === item.id}
+                    >
+                      {SUGGESTION_STATUSES.map((status) => (
+                        <option key={status} value={status}>
+                          {renderStatusLabel(status)}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+              </div>
+              {expanded ? (
+                <div className="suggestion-item__details">
+                  {isAdmin && item.author ? (
+                    <p className="suggestion-item__author">{t.suggestionsAdminAuthor(item.author)}</p>
+                  ) : null}
+                  <p className="suggestion-item__content">{item.content}</p>
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  return (
+    <main className="page suggestion-page" aria-labelledby="suggestion-title">
+      <h1 id="suggestion-title" className="page-title">
+        {t.suggestionsTitle}
+      </h1>
+      <p className="page-description">
+        {isAdmin ? t.suggestionsAdminDescription : t.suggestionsDescription}
+      </p>
+      {!isAdmin ? (
+        <form className="form suggestion-form" onSubmit={handleSubmit}>
+          <label className="form-field">
+            <span>{t.suggestionsFormTitle}</span>
+            <input
+              name="title"
+              type="text"
+              value={form.title}
+              onChange={updateField}
+              maxLength={200}
+              required
+            />
+          </label>
+          <label className="form-field">
+            <span>{t.suggestionsFormContent}</span>
+            <textarea
+              name="content"
+              value={form.content}
+              onChange={updateField}
+              rows={20}
+              maxLength={5000}
+              required
+            />
+          </label>
+          <div className="form-actions">
+            <button type="submit" disabled={submitState === 'loading'}>
+              {submitState === 'loading' ? '…' : t.suggestionsFormSubmit}
+            </button>
+          </div>
+          {feedback.message ? (
+            <p className={`form-message${feedback.type === 'error' ? ' error' : ''}`}>
+              {feedback.message}
+            </p>
+          ) : null}
+        </form>
+      ) : null}
+      <section className="suggestion-section" aria-live="polite">
+        <h2 className="visually-hidden">
+          {isAdmin ? t.suggestionsAdminListTitle : t.suggestionsListTitle}
+        </h2>
+        {renderList()}
+      </section>
+      {isAdmin && feedback.message ? (
+        <p className={`form-message${feedback.type === 'error' ? ' error' : ''}`}>
+          {feedback.message}
+        </p>
+      ) : null}
+    </main>
+  );
+}

--- a/nwleaderboard-ui/js/pages/Suggestions.js
+++ b/nwleaderboard-ui/js/pages/Suggestions.js
@@ -241,7 +241,7 @@ export default function Suggestions({ isAdmin }) {
               name="content"
               value={form.content}
               onChange={updateField}
-              rows={20}
+              rows={10}
               maxLength={5000}
               required
             />


### PR DESCRIPTION
## Summary
- add Suggestion JPA entity, repository, service, and REST resource for user submissions and admin review workflows
- build the authenticated suggestions page with submission form, admin status controls, styling, and locale strings
- expose the suggestions route and footer link while tracking the admin role on the frontend

## Testing
- mvn -f nwleaderboard-api/pom.xml -DskipTests package
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d839ac09a0832cac75b196adaad088