### PR TITLE
Restrict linking alternates to same-region mains

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorPlayerService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorPlayerService.java
@@ -128,6 +128,8 @@ public class ContributorPlayerService {
             throw new ContributorPlayerException("Main player not found");
         }
 
+        ensureSameRegionForLink(player, resolved);
+
         player.setMainCharacter(resolved);
         // Reassign alternates referencing this player to the resolved main to avoid chains.
         List<Player> dependants = playerRepository.listByMainCharacterId(player.getId());
@@ -145,6 +147,14 @@ public class ContributorPlayerService {
         String targetRegion = normaliseRegionId(target);
         if (!Objects.equals(sourceRegion, targetRegion)) {
             throw new ContributorPlayerException("Players must belong to the same region to be merged");
+        }
+    }
+
+    private void ensureSameRegionForLink(Player alt, Player main) {
+        String altRegion = normaliseRegionId(alt);
+        String mainRegion = normaliseRegionId(main);
+        if (altRegion == null || mainRegion == null || !Objects.equals(altRegion, mainRegion)) {
+            throw new ContributorPlayerException("Players must belong to the same region to be linked");
         }
     }
 

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -318,7 +318,8 @@ const en = {
   playerMainLinkSubmit: 'Link',
   playerMainLinkCancel: 'Cancel',
   playerMainLinkHint: 'Enter the main character name to associate. Leave empty to remove the link.',
-  playerMainLinkError: 'Unable to update the main character link.',
+  playerMainLinkError:
+    'Unable to update the main character link. Make sure both players belong to the same region.',
   playerSearchLoading: 'Searching players…',
   playerSearchError: 'Unable to search players right now.',
   playerSearchNoResults: 'No players match this search yet.',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -325,7 +325,8 @@ const fr = {
   playerMainLinkCancel: 'Annuler',
   playerMainLinkHint:
     'Saisissez le nom du personnage principal à associer. Laissez vide pour retirer le lien.',
-  playerMainLinkError: 'Impossible de lier ce personnage.',
+  playerMainLinkError:
+    'Impossible de lier ce personnage. Assurez-vous que les deux joueurs sont dans la même région.',
   playerSearchLoading: 'Recherche des joueurs…',
   playerSearchError: 'Impossible de rechercher des joueurs pour le moment.',
   playerSearchNoResults: 'Aucun joueur ne correspond pour le moment.',


### PR DESCRIPTION
## Summary
- require contributors to only link alternate characters to main characters from the same region in the API
- surface clearer guidance in the English and French UI copy when the linkage fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d86eb3b66c832cbe8c9d09c2e02a48