### PR TITLE
Expose preferences to all users and add theme slider

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -515,7 +515,8 @@ body[data-theme='light'] .highlight-list {
 }
 
 .form-field,
-.form-checkbox {
+.form-checkbox,
+.form-slider {
   display: flex;
   flex-direction: column;
   margin-bottom: 1.25rem;
@@ -527,12 +528,21 @@ body[data-theme='light'] .highlight-list {
 }
 
 .form-field span,
-.form-checkbox span {
+.form-checkbox span,
+.form-slider label {
   margin-bottom: 0.5rem;
   letter-spacing: 1px;
 }
 
 .form-checkbox span {
+  margin-bottom: 0;
+}
+
+.form-slider {
+  gap: 0.75rem;
+}
+
+.form-slider label {
   margin-bottom: 0;
 }
 
@@ -615,6 +625,98 @@ body[data-theme='light'] .form-field-floating input:not(:placeholder-shown) + sp
   flex-direction: row;
   align-items: center;
   gap: 0.75rem;
+}
+
+.theme-slider {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.theme-slider span {
+  font-size: 0.95rem;
+  opacity: 0.72;
+  letter-spacing: 0.5px;
+}
+
+.theme-slider input[type='range'] {
+  flex: 1;
+  -webkit-appearance: none;
+  background: transparent;
+  height: 2rem;
+  cursor: pointer;
+}
+
+.theme-slider input[type='range']::-webkit-slider-runnable-track {
+  height: 0.65rem;
+  background: rgba(124, 92, 255, 0.22);
+  border: 1px solid rgba(124, 92, 255, 0.45);
+  border-radius: 999px;
+  box-shadow: inset 0 1px 2px rgba(12, 18, 38, 0.4);
+}
+
+.theme-slider input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 1.6rem;
+  width: 1.6rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.45), rgba(124, 92, 255, 0.7));
+  border: 1px solid rgba(124, 92, 255, 0.6);
+  box-shadow: 0 12px 24px rgba(124, 92, 255, 0.4);
+  margin-top: -0.5rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-slider input[type='range']:focus-visible::-webkit-slider-thumb {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 3px;
+}
+
+.theme-slider input[type='range']::-moz-range-track {
+  height: 0.65rem;
+  background: rgba(124, 92, 255, 0.22);
+  border: 1px solid rgba(124, 92, 255, 0.45);
+  border-radius: 999px;
+  box-shadow: inset 0 1px 2px rgba(12, 18, 38, 0.4);
+}
+
+.theme-slider input[type='range']::-moz-range-thumb {
+  height: 1.6rem;
+  width: 1.6rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.45), rgba(124, 92, 255, 0.7));
+  border: 1px solid rgba(124, 92, 255, 0.6);
+  box-shadow: 0 12px 24px rgba(124, 92, 255, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-slider input[type='range']:focus-visible::-moz-range-thumb {
+  outline: 2px solid rgba(124, 92, 255, 0.6);
+  outline-offset: 3px;
+}
+
+.theme-slider input[type='range']:active::-webkit-slider-thumb,
+.theme-slider input[type='range']:active::-moz-range-thumb {
+  transform: scale(1.04);
+  box-shadow: 0 16px 28px rgba(124, 92, 255, 0.45);
+}
+
+body[data-theme='light'] .theme-slider span {
+  opacity: 0.65;
+}
+
+body[data-theme='light'] .theme-slider input[type='range']::-webkit-slider-runnable-track,
+body[data-theme='light'] .theme-slider input[type='range']::-moz-range-track {
+  background: rgba(124, 92, 255, 0.14);
+  border-color: rgba(124, 92, 255, 0.35);
+  box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.16);
+}
+
+body[data-theme='light'] .theme-slider input[type='range']::-webkit-slider-thumb,
+body[data-theme='light'] .theme-slider input[type='range']::-moz-range-thumb {
+  background: radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.9), rgba(124, 92, 255, 0.65));
+  border-color: rgba(124, 92, 255, 0.5);
+  box-shadow: 0 10px 22px rgba(124, 92, 255, 0.32);
 }
 
 .form-actions {

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -118,16 +118,19 @@ body[data-theme='light'] .site-header {
   margin: 0 auto;
   padding: clamp(1rem, 3vw, 1.6rem) clamp(1rem, 4vw, 1.75rem);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
   gap: clamp(0.75rem, 2vw, 1.1rem);
 }
 
 .site-header__brand {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: clamp(0.75rem, 2vw, 1.35rem);
-  text-align: center;
+  text-align: left;
 }
 
 .site-header__logo {
@@ -154,7 +157,9 @@ body[data-theme='light'] .site-header__title {
 
 .site-nav {
   display: flex;
-  justify-content: center;
+  flex: 1 1 auto;
+  justify-content: flex-end;
+  min-width: clamp(16rem, 50%, 28rem);
 }
 
 .site-nav__sections {
@@ -163,7 +168,7 @@ body[data-theme='light'] .site-header__title {
   justify-content: space-between;
   gap: clamp(0.75rem, 2.5vw, 1.75rem);
   flex-wrap: wrap;
-  align-items: flex-start;
+  align-items: center;
 }
 
 .site-nav__group {

--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -107,9 +107,7 @@ export default function App() {
               />
               <Route
                 path="/preferences"
-                element={
-                  authenticated ? <Preferences /> : <Navigate to="/login" replace />
-                }
+                element={<Preferences isAuthenticated={authenticated} />}
               />
               <Route
                 path="/contribute/*"

--- a/nwleaderboard-ui/js/BottomNav.js
+++ b/nwleaderboard-ui/js/BottomNav.js
@@ -32,6 +32,7 @@ export default function BottomNav({ authenticated, canContribute = false, onLogo
     </>
   ) : (
     <>
+      <NavButton to="/preferences">{t.preferences}</NavButton>
       <NavButton to="/login">{t.login}</NavButton>
       <NavButton to="/register">{t.register}</NavButton>
       <NavButton to="/forgot-password">{t.forgotPassword}</NavButton>

--- a/nwleaderboard-ui/js/Header.js
+++ b/nwleaderboard-ui/js/Header.js
@@ -305,24 +305,26 @@ export default function Header({ authenticated, canContribute = false, onLogout 
               </li>
             </ul>
             <ul className="site-nav__group site-nav__group--right">
+              <li className="site-nav__item">
+                <SiteNavLink
+                  to="/preferences"
+                  isActiveOverride={location.pathname.startsWith('/preferences')}
+                  onClick={closeMenus}
+                >
+                  {t.preferences}
+                </SiteNavLink>
+              </li>
               {isAuthenticated ? (
-                <>
-                  <li className="site-nav__item">
-                    <SiteNavLink to="/preferences" isActiveOverride={location.pathname.startsWith('/preferences')}>
-                      {t.preferences}
-                    </SiteNavLink>
-                  </li>
-                  <li className="site-nav__item">
-                    <SiteNavButton
-                      onClick={() => {
-                        closeMenus();
-                        onLogout();
-                      }}
-                    >
-                      {t.logout}
-                    </SiteNavButton>
-                  </li>
-                </>
+                <li className="site-nav__item">
+                  <SiteNavButton
+                    onClick={() => {
+                      closeMenus();
+                      onLogout();
+                    }}
+                  >
+                    {t.logout}
+                  </SiteNavButton>
+                </li>
               ) : (
                 <>
                   <li className="site-nav__item">

--- a/nwleaderboard-ui/js/Header.js
+++ b/nwleaderboard-ui/js/Header.js
@@ -139,9 +139,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
             width="56"
             height="56"
           />
-          <span className="site-header__title">
-            New World Stats By oPy - PvE Forever!
-          </span>
+          <span className="site-header__title">NWLeaderboard - PvE By oPy</span>
         </div>
         <nav className="site-nav" aria-label={t.navMenu}>
           <div className="site-nav__sections">

--- a/nwleaderboard-ui/js/pages/Preferences.js
+++ b/nwleaderboard-ui/js/pages/Preferences.js
@@ -14,20 +14,26 @@ const languageOptions = [
   { value: 'pt', label: 'Português' },
 ];
 
-export default function Preferences() {
+export default function Preferences({ isAuthenticated = false }) {
   const { t, lang, changeLang } = React.useContext(LangContext);
-  const { theme, toggleTheme } = React.useContext(ThemeContext);
+  const { theme, setTheme } = React.useContext(ThemeContext);
   const [messageKey, setMessageKey] = React.useState('');
   const navigate = useNavigate();
 
   const handleLanguageChange = (event) => {
-    changeLang(event.target.value);
-    setMessageKey('preferencesSaved');
+    const nextLang = event.target.value;
+    if (nextLang !== lang) {
+      changeLang(nextLang);
+      setMessageKey('preferencesSaved');
+    }
   };
 
-  const handleThemeChange = () => {
-    toggleTheme();
-    setMessageKey('preferencesSaved');
+  const handleThemeChange = (event) => {
+    const nextTheme = event.target.value === '1' ? 'dark' : 'light';
+    if (nextTheme !== theme) {
+      setTheme(nextTheme);
+      setMessageKey('preferencesSaved');
+    }
   };
 
   const goToPasswordPage = () => {
@@ -41,9 +47,13 @@ export default function Preferences() {
       </h1>
       <p className="page-description">{t.preferencesDescription}</p>
       <section className="form">
-        <label className="form-field">
+        <label className="form-field" htmlFor="language-select">
           <span>{t.language}</span>
-          <select value={lang} onChange={handleLanguageChange}>
+          <select
+            id="language-select"
+            value={lang}
+            onChange={handleLanguageChange}
+          >
             {languageOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
@@ -51,17 +61,30 @@ export default function Preferences() {
             ))}
           </select>
         </label>
-        <div className="form-checkbox">
-          <span>{t.theme}</span>
-          <button type="button" onClick={handleThemeChange}>
-            {t.themeToggle} ({theme === 'dark' ? t.themeDark : t.themeLight})
-          </button>
+        <div className="form-slider">
+          <label htmlFor="theme-slider">{t.theme}</label>
+          <div className="theme-slider">
+            <span aria-hidden="true">{t.themeLight}</span>
+            <input
+              id="theme-slider"
+              type="range"
+              min="0"
+              max="1"
+              step="1"
+              value={theme === 'dark' ? '1' : '0'}
+              onChange={handleThemeChange}
+              aria-valuetext={theme === 'dark' ? t.themeDark : t.themeLight}
+            />
+            <span aria-hidden="true">{t.themeDark}</span>
+          </div>
         </div>
-        <div className="form-actions">
-          <button type="button" onClick={goToPasswordPage}>
-            {t.password}
-          </button>
-        </div>
+        {isAuthenticated ? (
+          <div className="form-actions">
+            <button type="button" onClick={goToPasswordPage}>
+              {t.password}
+            </button>
+          </div>
+        ) : null}
       </section>
       {messageKey ? (
         <p className="form-message">{t[messageKey]}</p>


### PR DESCRIPTION
## Summary
- replace the theme toggle button with a styled slider that drives the existing theme preference persistence
- keep the language change message local and guard against redundant updates while storing preferences in local storage
- allow everyone to access the preferences page, hide the password change action for guests, and surface the entry points in the header and bottom navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8713b21fc832c81a76263e7e90dc6