### PR TITLE
Add season management to contributor mutations

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationCreateRequest.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationCreateRequest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record ContributorMutationCreateRequest(
         Integer week,
         @JsonProperty("dungeon_id") Long dungeonId,
+        @JsonProperty("season_id") Integer seasonId,
         @JsonProperty("mutation_element_id") String mutationElementId,
         @JsonProperty("mutation_type_id") String mutationTypeId,
         @JsonProperty("mutation_promotion_id") String mutationPromotionId,

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationEntryResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationEntryResponse.java
@@ -7,6 +7,7 @@ import java.util.Map;
  * Response payload describing the mutation configuration for a dungeon in a given week.
  */
 public record ContributorMutationEntryResponse(
+        @JsonProperty("season_id") Integer seasonId,
         Integer week,
         @JsonProperty("dungeon_id") Long dungeonId,
         @JsonProperty("dungeon_names") Map<String, String> dungeonNames,

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationOptionsResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationOptionsResponse.java
@@ -10,4 +10,5 @@ public record ContributorMutationOptionsResponse(
         List<String> elements,
         List<String> types,
         List<String> promotions,
-        List<String> curses) {}
+        List<String> curses,
+        List<ContributorSeasonOption> seasons) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationUpdateRequest.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorMutationUpdateRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Request payload used when updating an existing weekly mutation entry.
  */
 public record ContributorMutationUpdateRequest(
+        @JsonProperty("season_id") Integer seasonId,
         @JsonProperty("mutation_element_id") String mutationElementId,
         @JsonProperty("mutation_type_id") String mutationTypeId,
         @JsonProperty("mutation_promotion_id") String mutationPromotionId,

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorSeasonOption.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorSeasonOption.java
@@ -1,0 +1,12 @@
+package com.opyruso.nwleaderboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+
+/**
+ * Response payload describing a selectable season.
+ */
+public record ContributorSeasonOption(
+        Integer id,
+        @JsonProperty("date_begin") LocalDate dateBegin,
+        @JsonProperty("date_end") LocalDate dateEnd) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Season.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Season.java
@@ -1,0 +1,52 @@
+package com.opyruso.nwleaderboard.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+
+/**
+ * Entity representing a gameplay season.
+ */
+@Entity
+@Table(name = "season")
+public class Season extends Auditable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_saison")
+    private Integer id;
+
+    @Column(name = "date_begin", nullable = false)
+    private LocalDate dateBegin;
+
+    @Column(name = "date_end", nullable = false)
+    private LocalDate dateEnd;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public LocalDate getDateBegin() {
+        return dateBegin;
+    }
+
+    public void setDateBegin(LocalDate dateBegin) {
+        this.dateBegin = dateBegin;
+    }
+
+    public LocalDate getDateEnd() {
+        return dateEnd;
+    }
+
+    public void setDateEnd(LocalDate dateEnd) {
+        this.dateEnd = dateEnd;
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeon.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeon.java
@@ -39,6 +39,10 @@ public class WeekMutationDungeon extends Auditable {
     @JoinColumn(name = "id_mutation_curse", nullable = false)
     private MutationCurse mutationCurse;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_saison")
+    private Season season;
+
     public WeekMutationDungeonId getId() {
         return id;
     }
@@ -100,5 +104,13 @@ public class WeekMutationDungeon extends Auditable {
 
     public void setMutationCurse(MutationCurse mutationCurse) {
         this.mutationCurse = mutationCurse;
+    }
+
+    public Season getSeason() {
+        return season;
+    }
+
+    public void setSeason(Season season) {
+        this.season = season;
     }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/SeasonRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/SeasonRepository.java
@@ -1,0 +1,21 @@
+package com.opyruso.nwleaderboard.repository;
+
+import com.opyruso.nwleaderboard.entity.Season;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+
+/**
+ * Repository exposing CRUD operations for {@link Season} entities.
+ */
+@ApplicationScoped
+public class SeasonRepository implements PanacheRepositoryBase<Season, Integer> {
+
+    public List<Season> listAllOrderByDateBeginDesc() {
+        return find("ORDER BY dateBegin DESC").list();
+    }
+
+    public Season findLatestByDateBegin() {
+        return find("ORDER BY dateBegin DESC").firstResult();
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/WeekMutationDungeonRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/WeekMutationDungeonRepository.java
@@ -1,5 +1,6 @@
 package com.opyruso.nwleaderboard.repository;
 
+import com.opyruso.nwleaderboard.entity.Season;
 import com.opyruso.nwleaderboard.entity.WeekMutationDungeon;
 import com.opyruso.nwleaderboard.entity.WeekMutationDungeonId;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
@@ -21,7 +22,8 @@ public class WeekMutationDungeonRepository implements PanacheRepositoryBase<Week
                                 + "JOIN FETCH w.mutationElement "
                                 + "JOIN FETCH w.mutationType "
                                 + "JOIN FETCH w.mutationPromotion "
-                                + "JOIN FETCH w.mutationCurse",
+                                + "JOIN FETCH w.mutationCurse "
+                                + "LEFT JOIN FETCH w.season",
                         WeekMutationDungeon.class)
                 .getResultList();
     }
@@ -64,5 +66,18 @@ public class WeekMutationDungeonRepository implements PanacheRepositoryBase<Week
             query.setParameter("curseIds", curseIds);
         }
         return query.getResultList();
+    }
+
+    public int assignSeasonToPreviousWeeks(Integer week, Season season) {
+        if (week == null || season == null) {
+            return 0;
+        }
+        return getEntityManager()
+                .createQuery(
+                        "UPDATE WeekMutationDungeon w SET w.season = :season "
+                                + "WHERE w.id.week <= :week AND w.season IS NULL")
+                .setParameter("season", season)
+                .setParameter("week", week)
+                .executeUpdate();
     }
 }

--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -71,6 +71,7 @@ const de = {
   contributeMutationsAddRow: 'Mutation hinzufügen',
   contributeMutationsLoading: 'Mutationen werden geladen…',
   contributeMutationsError: 'Die Mutationsliste konnte nicht geladen werden.',
+  contributeMutationsSeason: 'Saison',
   contributeMutationsWeek: 'Woche',
   contributeMutationsDungeon: 'Dungeon',
   contributeMutationsElement: 'Element',
@@ -93,6 +94,7 @@ const de = {
   contributeMutationsDeleteError: 'Mutation konnte nicht gelöscht werden.',
   contributeMutationsWeekRequired: 'Bitte die Wochennummer eingeben.',
   contributeMutationsDungeonRequired: 'Bitte einen Dungeon auswählen.',
+  contributeMutationsSeasonRequired: 'Wähle eine Saison aus.',
   contributeMutationsSelectionRequired: 'Alle Werte auswählen, bevor du hinzufügst.',
   contributeMutationsDuplicateError: 'Für diese Woche und diesen Dungeon existiert bereits eine Mutation.',
   contributeStatsDescription:

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -71,6 +71,7 @@ const en = {
   contributeMutationsAddRow: 'Add mutation',
   contributeMutationsLoading: 'Loading mutations…',
   contributeMutationsError: 'Unable to load the mutation list.',
+  contributeMutationsSeason: 'Season',
   contributeMutationsWeek: 'Week',
   contributeMutationsDungeon: 'Dungeon',
   contributeMutationsElement: 'Element',
@@ -93,6 +94,7 @@ const en = {
   contributeMutationsDeleteError: 'Unable to delete this mutation.',
   contributeMutationsWeekRequired: 'Enter the week number.',
   contributeMutationsDungeonRequired: 'Select a dungeon.',
+  contributeMutationsSeasonRequired: 'Select a season.',
   contributeMutationsSelectionRequired: 'Select all mutation values before adding.',
   contributeMutationsDuplicateError: 'A mutation already exists for this week and dungeon.',
   contributeStatsDescription:

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -72,6 +72,7 @@ const es = {
   contributeMutationsAddRow: 'Añadir mutación',
   contributeMutationsLoading: 'Cargando mutaciones…',
   contributeMutationsError: 'No se puede cargar la lista de mutaciones.',
+  contributeMutationsSeason: 'Temporada',
   contributeMutationsWeek: 'Semana',
   contributeMutationsDungeon: 'Mazmorra',
   contributeMutationsElement: 'Elemento',
@@ -94,6 +95,7 @@ const es = {
   contributeMutationsDeleteError: 'No se puede eliminar esta mutación.',
   contributeMutationsWeekRequired: 'Introduce el número de semana.',
   contributeMutationsDungeonRequired: 'Selecciona una mazmorra.',
+  contributeMutationsSeasonRequired: 'Selecciona una temporada.',
   contributeMutationsSelectionRequired: 'Selecciona todos los valores antes de añadir.',
   contributeMutationsDuplicateError: 'Ya existe una mutación para esta semana y mazmorra.',
   contributeStatsDescription:

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -71,6 +71,7 @@ const esmx = {
   contributeMutationsAddRow: 'Agregar mutación',
   contributeMutationsLoading: 'Cargando mutaciones…',
   contributeMutationsError: 'No se puede cargar la lista de mutaciones.',
+  contributeMutationsSeason: 'Temporada',
   contributeMutationsWeek: 'Semana',
   contributeMutationsDungeon: 'Mazmorra',
   contributeMutationsElement: 'Elemento',
@@ -93,6 +94,7 @@ const esmx = {
   contributeMutationsDeleteError: 'No se puede eliminar esta mutación.',
   contributeMutationsWeekRequired: 'Ingresa el número de semana.',
   contributeMutationsDungeonRequired: 'Selecciona una mazmorra.',
+  contributeMutationsSeasonRequired: 'Selecciona una temporada.',
   contributeMutationsSelectionRequired: 'Selecciona todos los valores antes de agregar.',
   contributeMutationsDuplicateError: 'Ya existe una mutación para esa semana y mazmorra.',
   contributeStatsDescription:

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -71,6 +71,7 @@ const fr = {
   contributeMutationsAddRow: 'Ajouter une mutation',
   contributeMutationsLoading: 'Chargement des mutations…',
   contributeMutationsError: 'Impossible de charger la liste des mutations.',
+  contributeMutationsSeason: 'Saison',
   contributeMutationsWeek: 'Semaine',
   contributeMutationsDungeon: 'Donjon',
   contributeMutationsElement: 'Élément',
@@ -93,6 +94,7 @@ const fr = {
   contributeMutationsDeleteError: 'Impossible de supprimer cette mutation.',
   contributeMutationsWeekRequired: 'Indiquez le numéro de semaine.',
   contributeMutationsDungeonRequired: 'Sélectionnez un donjon.',
+  contributeMutationsSeasonRequired: 'Sélectionnez une saison.',
   contributeMutationsSelectionRequired: 'Sélectionnez toutes les valeurs avant d’ajouter.',
   contributeMutationsDuplicateError: 'Une mutation existe déjà pour cette semaine et ce donjon.',
   contributeStatsDescription:

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -71,6 +71,7 @@ const it = {
   contributeMutationsAddRow: 'Aggiungi mutazione',
   contributeMutationsLoading: 'Caricamento mutazioni…',
   contributeMutationsError: 'Impossibile caricare l’elenco delle mutazioni.',
+  contributeMutationsSeason: 'Stagione',
   contributeMutationsWeek: 'Settimana',
   contributeMutationsDungeon: 'Spedizione',
   contributeMutationsElement: 'Elemento',
@@ -93,6 +94,7 @@ const it = {
   contributeMutationsDeleteError: 'Impossibile eliminare la mutazione.',
   contributeMutationsWeekRequired: 'Inserisci il numero di settimana.',
   contributeMutationsDungeonRequired: 'Seleziona una spedizione.',
+  contributeMutationsSeasonRequired: 'Seleziona una stagione.',
   contributeMutationsSelectionRequired: 'Seleziona tutti i valori prima di aggiungere.',
   contributeMutationsDuplicateError: 'Esiste già una mutazione per questa settimana e spedizione.',
   contributeStatsDescription:

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -71,6 +71,7 @@ const pl = {
   contributeMutationsAddRow: 'Dodaj mutację',
   contributeMutationsLoading: 'Ładowanie mutacji…',
   contributeMutationsError: 'Nie udało się załadować listy mutacji.',
+  contributeMutationsSeason: 'Sezon',
   contributeMutationsWeek: 'Tydzień',
   contributeMutationsDungeon: 'Loch',
   contributeMutationsElement: 'Żywioł',
@@ -93,6 +94,7 @@ const pl = {
   contributeMutationsDeleteError: 'Nie można usunąć mutacji.',
   contributeMutationsWeekRequired: 'Podaj numer tygodnia.',
   contributeMutationsDungeonRequired: 'Wybierz loch.',
+  contributeMutationsSeasonRequired: 'Wybierz sezon.',
   contributeMutationsSelectionRequired: 'Wybierz wszystkie wartości przed dodaniem.',
   contributeMutationsDuplicateError: 'Mutacja dla tego tygodnia i lochu już istnieje.',
   contributeStatsDescription:

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -71,6 +71,7 @@ const pt = {
   contributeMutationsAddRow: 'Adicionar mutação',
   contributeMutationsLoading: 'Carregando mutações…',
   contributeMutationsError: 'Não foi possível carregar a lista de mutações.',
+  contributeMutationsSeason: 'Temporada',
   contributeMutationsWeek: 'Semana',
   contributeMutationsDungeon: 'Masmorra',
   contributeMutationsElement: 'Elemento',
@@ -93,6 +94,7 @@ const pt = {
   contributeMutationsDeleteError: 'Não foi possível excluir a mutação.',
   contributeMutationsWeekRequired: 'Informe o número da semana.',
   contributeMutationsDungeonRequired: 'Selecione uma masmorra.',
+  contributeMutationsSeasonRequired: 'Selecione uma temporada.',
   contributeMutationsSelectionRequired: 'Selecione todos os valores antes de adicionar.',
   contributeMutationsDuplicateError: 'Já existe uma mutação para esta semana e masmorra.',
   contributeStatsDescription:


### PR DESCRIPTION
## Summary
- add a Season entity/repository and relate it to weekly dungeon mutations
- expose season data through contributor mutation DTOs and assign seasons to previous unassigned weeks when updated
- surface season selection in the contributor mutations table UI with locale updates and defaulting to the latest season

## Testing
- mvn -f nwleaderboard-api/pom.xml -DskipTests package
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8ed2a88b0832ca8a877be2786155c