### PR TITLE
Handle manual season identifiers

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorSeasonUpdateRequest.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/ContributorSeasonUpdateRequest.java
@@ -7,5 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public record ContributorSeasonUpdateRequest(
         Integer id,
+        @JsonProperty("previous_id") Integer previousId,
         @JsonProperty("date_begin") String dateBegin,
         @JsonProperty("date_end") String dateEnd) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Season.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/Season.java
@@ -2,8 +2,6 @@ package com.opyruso.nwleaderboard.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
@@ -16,8 +14,7 @@ import java.time.LocalDate;
 public class Season extends Auditable {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id_saison")
+    @Column(name = "id_season")
     private Integer id;
 
     @Column(name = "date_begin", nullable = false)

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeon.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/entity/WeekMutationDungeon.java
@@ -40,7 +40,7 @@ public class WeekMutationDungeon extends Auditable {
     private MutationCurse mutationCurse;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "id_saison")
+    @JoinColumn(name = "id_season")
     private Season season;
 
     public WeekMutationDungeonId getId() {

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/SeasonRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/SeasonRepository.java
@@ -47,4 +47,14 @@ public class SeasonRepository implements PanacheRepositoryBase<Season, Integer> 
         }
         return find("dateBegin = ?1 AND dateEnd = ?2", dateBegin, dateEnd).firstResultOptional().isPresent();
     }
+
+    public int findNextAvailableId() {
+        Integer maxId =
+                getEntityManager().createQuery("SELECT MAX(s.id) FROM Season s", Integer.class).getSingleResult();
+        int candidate = (maxId != null ? maxId : 0) + 1;
+        while (existsById(candidate)) {
+            candidate++;
+        }
+        return candidate;
+    }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorSeasonService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/ContributorSeasonService.java
@@ -48,12 +48,12 @@ public class ContributorSeasonService {
         }
         Season season = new Season();
         Integer requestedId = normaliseOptionalSeasonId(request != null ? request.id() : null);
-        if (requestedId != null) {
-            if (seasonRepository.existsById(requestedId)) {
-                throw new ContributorSeasonException("Season identifier already exists.", Status.CONFLICT);
-            }
-            season.setId(requestedId);
+        if (requestedId == null) {
+            requestedId = seasonRepository.findNextAvailableId();
+        } else if (seasonRepository.existsById(requestedId)) {
+            throw new ContributorSeasonException("Season identifier already exists.", Status.CONFLICT);
         }
+        season.setId(requestedId);
         season.setDateBegin(dateBegin);
         season.setDateEnd(dateEnd);
         try {
@@ -73,8 +73,16 @@ public class ContributorSeasonService {
             throw new ContributorSeasonException("Season not found.", Status.NOT_FOUND);
         }
         if (request == null
-                || (isBlank(request.dateBegin()) && isBlank(request.dateEnd()) && request.id() == null)) {
+                || (isBlank(request.dateBegin())
+                        && isBlank(request.dateEnd())
+                        && request.id() == null
+                        && request.previousId() == null)) {
             throw new ContributorSeasonException("No updates were provided.", Status.BAD_REQUEST);
+        }
+        Integer providedPreviousId = normaliseOptionalSeasonId(request != null ? request.previousId() : null);
+        if (providedPreviousId != null && providedPreviousId != id) {
+            throw new ContributorSeasonException(
+                    "previous_id does not match the targeted season.", Status.BAD_REQUEST);
         }
         LocalDate currentBegin = season.getDateBegin();
         LocalDate currentEnd = season.getDateEnd();

--- a/nwleaderboard-ui/js/pages/ContributeSeasons.js
+++ b/nwleaderboard-ui/js/pages/ContributeSeasons.js
@@ -186,7 +186,7 @@ export default function ContributeSeasons() {
         setActiveEdit(null);
         return;
       }
-      payload = { id: numericValue };
+      payload = { id: numericValue, previous_id: previousId };
     } else {
       if (!rawValue) {
         setFeedback({ type: 'error', text: t.contributeSeasonsDateRequired });


### PR DESCRIPTION
## Summary
- rename season identifier column mappings to `id_season`
- ensure season creation assigns explicit identifiers and validate previous identifiers on update
- update the contributor seasons UI to send both previous and new identifiers when renaming seasons

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68d9069a6718832c88ec20fa357ba240