### PR TITLE
Add leaderboard chart aggregation endpoints and UI consumption

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
@@ -2,6 +2,7 @@ package com.opyruso.nwleaderboard;
 
 import com.opyruso.nwleaderboard.dto.ApiMessageResponse;
 import com.opyruso.nwleaderboard.dto.HighlightResponse;
+import com.opyruso.nwleaderboard.dto.LeaderboardChartResponse;
 import com.opyruso.nwleaderboard.dto.LeaderboardEntryResponse;
 import com.opyruso.nwleaderboard.dto.LeaderboardPageResponse;
 import com.opyruso.nwleaderboard.dto.IndividualRankingEntryResponse;
@@ -63,6 +64,24 @@ public class LeaderboardResource {
     }
 
     @GET
+    @Path("/score/chart")
+    public Response getScoreChart(
+            @QueryParam("dungeonId") Long dungeonId,
+            @QueryParam("mutationType") List<String> mutationTypeIds,
+            @QueryParam("mutationPromotion") List<String> mutationPromotionIds,
+            @QueryParam("mutationCurse") List<String> mutationCurseIds,
+            @QueryParam("region") List<String> regionIds) {
+        if (dungeonId == null) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
+                    .build();
+        }
+        LeaderboardChartResponse response = leaderboardService.getScoreChartData(
+                dungeonId, mutationTypeIds, mutationPromotionIds, mutationCurseIds, regionIds);
+        return Response.ok(response).build();
+    }
+
+    @GET
     @Path("/time")
     public Response getTime(
             @QueryParam("dungeonId") Long dungeonId,
@@ -85,6 +104,24 @@ public class LeaderboardResource {
                 mutationPromotionIds,
                 mutationCurseIds,
                 regionIds);
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/time/chart")
+    public Response getTimeChart(
+            @QueryParam("dungeonId") Long dungeonId,
+            @QueryParam("mutationType") List<String> mutationTypeIds,
+            @QueryParam("mutationPromotion") List<String> mutationPromotionIds,
+            @QueryParam("mutationCurse") List<String> mutationCurseIds,
+            @QueryParam("region") List<String> regionIds) {
+        if (dungeonId == null) {
+            return Response.status(Status.BAD_REQUEST)
+                    .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
+                    .build();
+        }
+        LeaderboardChartResponse response = leaderboardService.getTimeChartData(
+                dungeonId, mutationTypeIds, mutationPromotionIds, mutationCurseIds, regionIds);
         return Response.ok(response).build();
     }
 

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardChartResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardChartResponse.java
@@ -1,0 +1,11 @@
+package com.opyruso.nwleaderboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LeaderboardChartResponse(List<LeaderboardChartWeekResponse> weeks, Double globalAverage) {
+    public LeaderboardChartResponse {
+        weeks = weeks == null ? List.of() : List.copyOf(weeks);
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardChartWeekResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/LeaderboardChartWeekResponse.java
@@ -1,0 +1,10 @@
+package com.opyruso.nwleaderboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LeaderboardChartWeekResponse(
+        Integer week,
+        Double bestValue,
+        Double worstValue,
+        Long runCount) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
@@ -68,6 +68,36 @@ public class RunTimeRepository implements PanacheRepository<RunTime> {
         return find(query.toString(), parameters).page(Page.of(pageIndex, pageSize)).list();
     }
 
+    public List<Object[]> aggregateByDungeonAndWeeks(
+            Long dungeonId, List<Integer> weeks, Collection<String> regions) {
+        if (dungeonId == null) {
+            return List.of();
+        }
+        if (weeks != null && weeks.isEmpty()) {
+            return List.of();
+        }
+        StringBuilder query = new StringBuilder(
+                "SELECT run.week, MAX(run.timeInSecond), MIN(run.timeInSecond), SUM(run.timeInSecond), COUNT(run.id) "
+                        + "FROM RunTime run WHERE run.dungeon.id = :dungeonId");
+        if (weeks != null) {
+            query.append(" AND run.week IN :weeks");
+        }
+        if (regions != null && !regions.isEmpty()) {
+            query.append(" AND run.region.id IN :regions");
+        }
+        query.append(" GROUP BY run.week");
+
+        var typedQuery = getEntityManager().createQuery(query.toString(), Object[].class);
+        typedQuery.setParameter("dungeonId", dungeonId);
+        if (weeks != null) {
+            typedQuery.setParameter("weeks", weeks);
+        }
+        if (regions != null && !regions.isEmpty()) {
+            typedQuery.setParameter("regions", regions);
+        }
+        return typedQuery.getResultList();
+    }
+
     public long countByDungeonAndWeeks(Long dungeonId, List<Integer> weeks, Collection<String> regions) {
         if (dungeonId == null) {
             return 0L;


### PR DESCRIPTION
## Summary
- add API endpoints to provide aggregated score and time chart data with new DTOs and repository aggregation helpers
- extend the leaderboard service to compute chart responses and expose helper logic
- update the leaderboard UI to request the new chart data and render best, worst, and average series across all filtered runs

## Testing
- mvn -f nwleaderboard-api/pom.xml test
- npm --prefix nwleaderboard-ui test

------
https://chatgpt.com/codex/tasks/task_e_68d907aa33a8832ca43881e9c79af136