### PR TITLE
Display season IDs in contributor mutations list

### DIFF
--- a/nwleaderboard-ui/js/pages/ContributeMutations.js
+++ b/nwleaderboard-ui/js/pages/ContributeMutations.js
@@ -65,7 +65,7 @@ function normaliseEntry(entry, index = 0) {
   const dungeonIdValue = Number(entry.dungeon_id ?? entry.dungeonId);
   const dungeonId = Number.isFinite(dungeonIdValue) ? dungeonIdValue : null;
   const dungeonNames = normaliseNames(entry.dungeon_names ?? entry.dungeonNames);
-  const seasonValue = Number(entry.season_id ?? entry.seasonId);
+  const seasonValue = Number(entry.season_id ?? entry.seasonId ?? entry.id_season ?? entry.idSeason);
   const seasonId = Number.isFinite(seasonValue) ? seasonValue : null;
   const element = typeof entry.mutation_element_id === 'string' ? entry.mutation_element_id.trim() : '';
   const type = typeof entry.mutation_type_id === 'string' ? entry.mutation_type_id.trim() : '';
@@ -138,7 +138,9 @@ function normaliseSeasonOption(option) {
   if (!option || typeof option !== 'object') {
     return null;
   }
-  const idValue = Number(option.id ?? option.season_id ?? option.seasonId);
+  const idValue = Number(
+    option.id ?? option.season_id ?? option.seasonId ?? option.id_season ?? option.idSeason,
+  );
   const id = Number.isFinite(idValue) ? idValue : null;
   if (id === null) {
     return null;

--- a/nwleaderboard-ui/js/pages/ContributeMutations.js
+++ b/nwleaderboard-ui/js/pages/ContributeMutations.js
@@ -164,17 +164,6 @@ function normaliseSeasonOption(option) {
   };
 }
 
-function getSeasonLabelById(list, seasonId) {
-  const numericId = Number(seasonId);
-  if (!Number.isFinite(numericId)) {
-    return '';
-  }
-  const match = Array.isArray(list)
-    ? list.find((item) => Number.isFinite(item?.id) && Number(item.id) === numericId)
-    : null;
-  return match ? match.label || String(match.id) : '';
-}
-
 function sortSeasonOptions(list) {
   if (!Array.isArray(list)) {
     return [];
@@ -698,7 +687,11 @@ export default function ContributeMutations() {
       : [];
     const rawValue = entry[field];
     const value = rawValue === undefined || rawValue === null ? '' : rawValue;
-    const displayValue = isSeasonField ? getSeasonLabelById(optionsList, value) : value || label;
+    const displayValue = isSeasonField
+      ? value === undefined || value === null || value === ''
+        ? ''
+        : String(value)
+      : value || label;
 
     return (
       <td


### PR DESCRIPTION
## Summary
- show the numeric season identifier in the contributor mutations table instead of the date label
- clean up unused helper used for formatting season labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d989489adc832c9ad9866458445680