### PR TITLE
Show highlight region labels

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1297,6 +1297,22 @@ body[data-theme='light'] .highlight-item {
   gap: 1.25rem;
 }
 
+.highlight-footer {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-top: auto;
+  padding-top: 0.5rem;
+}
+
+.highlight-region {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  align-self: flex-start;
+}
+
 .highlight-metric {
   display: flex;
   flex-direction: column;

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -12,6 +12,7 @@ import {
 import { extractMutationIds } from '../mutations.js';
 import { capitaliseWords } from '../text.js';
 import { formatPlayerLinkProps } from '../playerNames.js';
+import { extractRegionId, translateRegion } from '../regions.js';
 
 const { Link } = ReactRouterDOM;
 
@@ -92,6 +93,7 @@ function normaliseHighlight(entry, index) {
   const playerCount = toPositiveInteger(entry.player_count ?? entry.playerCount);
   const score = normaliseMetric(entry.best_score ?? entry.score ?? entry.bestScore);
   const time = normaliseMetric(entry.best_time ?? entry.time ?? entry.bestTime);
+  const region = extractRegionId(entry);
   return {
     id,
     names,
@@ -100,6 +102,7 @@ function normaliseHighlight(entry, index) {
     playerCount,
     score,
     time,
+    region,
   };
 }
 
@@ -212,6 +215,7 @@ export default function Home() {
               const timeValue = time ? formatTime(time.value) : t.highlightNoTime;
               const scoreWeek = score && score.week ? score.week : null;
               const timeWeek = time && time.week ? time.week : null;
+              const regionLabel = highlight.region ? translateRegion(t, highlight.region) : '';
               return (
                 <li key={highlight.id} className="highlight-item">
                   <header className="highlight-header">
@@ -323,6 +327,11 @@ export default function Home() {
                       />
                     </div>
                   </div>
+                  {regionLabel ? (
+                    <div className="highlight-footer">
+                      <span className="highlight-region">{regionLabel}</span>
+                    </div>
+                  ) : null}
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary
- extract region identifiers for highlight entries and translate them for display
- add a footer to highlight cards that surfaces the region label at the bottom left

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d98c7d484c832cb785a9d1f1cb73ba