### PR TITLE
Group Contribute menu links into Organisation and Data sections

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -290,11 +290,42 @@ body[data-theme='light'] .site-nav__dropdown-menu {
   pointer-events: auto;
 }
 
-.site-nav__dropdown-menu li {
+.site-nav__dropdown-menu > li {
   list-style: none;
   margin: 0;
   border-radius: 12px;
   overflow: hidden;
+}
+
+.site-nav__dropdown-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.45rem;
+  background: var(--surface-dark-soft);
+}
+
+body[data-theme='light'] .site-nav__dropdown-section {
+  background: var(--surface-light-soft);
+}
+
+.site-nav__dropdown-title {
+  margin: 0;
+  padding: 0 0.25rem;
+  font-size: clamp(0.72rem, 1vw, 0.82rem);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.site-nav__dropdown-submenu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .site-nav__dropdown-menu .site-nav__link {

--- a/nwleaderboard-ui/js/Header.js
+++ b/nwleaderboard-ui/js/Header.js
@@ -175,69 +175,82 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                     )}
                     aria-hidden={contributeMenuOpen ? undefined : 'true'}
                   >
-                    <li>
-                      <SiteNavLink
-                        to="/contribute"
-                        className="site-nav__sublink"
-                        end
-                        onClick={closeMenus}
+                    <li className="site-nav__dropdown-section">
+                      <p className="site-nav__dropdown-title">{t.contributeMenuOrganisation}</p>
+                      <ul
+                        className="site-nav__dropdown-submenu"
+                        aria-label={t.contributeMenuOrganisation}
                       >
-                        {t.contributeMenuDungeons}
-                      </SiteNavLink>
+                        <li>
+                          <SiteNavLink
+                            to="/contribute"
+                            className="site-nav__sublink"
+                            end
+                            onClick={closeMenus}
+                          >
+                            {t.contributeMenuDungeons}
+                          </SiteNavLink>
+                        </li>
+                        <li>
+                          <SiteNavLink
+                            to="/contribute/mutations"
+                            className="site-nav__sublink"
+                            onClick={closeMenus}
+                          >
+                            {t.contributeMenuMutations}
+                          </SiteNavLink>
+                        </li>
+                        <li>
+                          <SiteNavLink
+                            to="/contribute/seasons"
+                            className="site-nav__sublink"
+                            onClick={closeMenus}
+                          >
+                            {t.contributeMenuSeasons}
+                          </SiteNavLink>
+                        </li>
+                      </ul>
                     </li>
-                    <li>
-                      <SiteNavLink
-                        to="/contribute/mutations"
-                        className="site-nav__sublink"
-                        onClick={closeMenus}
-                      >
-                        {t.contributeMenuMutations}
-                      </SiteNavLink>
-                    </li>
-                    <li>
-                      <SiteNavLink
-                        to="/contribute/seasons"
-                        className="site-nav__sublink"
-                        onClick={closeMenus}
-                      >
-                        {t.contributeMenuSeasons}
-                      </SiteNavLink>
-                    </li>
-                    <li>
-                      <SiteNavLink
-                        to="/contribute/import"
-                        className="site-nav__sublink"
-                        onClick={closeMenus}
-                      >
-                        {t.contributeMenuImport}
-                      </SiteNavLink>
-                    </li>
-                    <li>
-                      <SiteNavLink
-                        to="/contribute/validate"
-                        className="site-nav__sublink"
-                        onClick={closeMenus}
-                      >
-                        {t.contributeMenuValidate}
-                      </SiteNavLink>
-                    </li>
-                    <li>
-                      <SiteNavLink
-                        to="/contribute/stats"
-                        className="site-nav__sublink"
-                        onClick={closeMenus}
-                      >
-                        {t.contributeMenuStats}
-                      </SiteNavLink>
-                    </li>
-                    <li>
-                      <SiteNavLink
-                        to="/contribute/players"
-                        className="site-nav__sublink"
-                        onClick={closeMenus}
-                      >
-                        {t.contributeMenuPlayers}
-                      </SiteNavLink>
+                    <li className="site-nav__dropdown-section">
+                      <p className="site-nav__dropdown-title">{t.contributeMenuData}</p>
+                      <ul className="site-nav__dropdown-submenu" aria-label={t.contributeMenuData}>
+                        <li>
+                          <SiteNavLink
+                            to="/contribute/import"
+                            className="site-nav__sublink"
+                            onClick={closeMenus}
+                          >
+                            {t.contributeMenuImport}
+                          </SiteNavLink>
+                        </li>
+                        <li>
+                          <SiteNavLink
+                            to="/contribute/validate"
+                            className="site-nav__sublink"
+                            onClick={closeMenus}
+                          >
+                            {t.contributeMenuValidate}
+                          </SiteNavLink>
+                        </li>
+                        <li>
+                          <SiteNavLink
+                            to="/contribute/stats"
+                            className="site-nav__sublink"
+                            onClick={closeMenus}
+                          >
+                            {t.contributeMenuStats}
+                          </SiteNavLink>
+                        </li>
+                        <li>
+                          <SiteNavLink
+                            to="/contribute/players"
+                            className="site-nav__sublink"
+                            onClick={closeMenus}
+                          >
+                            {t.contributeMenuPlayers}
+                          </SiteNavLink>
+                        </li>
+                      </ul>
                     </li>
                   </ul>
                 </li>

--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -52,6 +52,8 @@ const de = {
   contributeToggleCompactLabel: 'Kompakte Ansicht',
   contributeReadyForSubmission: 'Bereit zum Senden.',
   contributeMenuLabel: 'Bereiche für Mitwirkende',
+  contributeMenuOrganisation: 'Organisation',
+  contributeMenuData: 'Daten',
   contributeMenuDungeons: 'Dungeons',
   contributeMenuMutations: 'Wöchentliche Mutationen',
   contributeMenuSeasons: 'Saisonverwaltung',

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -52,6 +52,8 @@ const en = {
   contributeToggleCompactLabel: 'Compact layout',
   contributeReadyForSubmission: 'Ready to submit.',
   contributeMenuLabel: 'Contributor sections',
+  contributeMenuOrganisation: 'Organisation',
+  contributeMenuData: 'Data',
   contributeMenuDungeons: 'Dungeons',
   contributeMenuMutations: 'Weekly mutations',
   contributeMenuSeasons: 'Season management',

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -53,6 +53,8 @@ const es = {
   contributeToggleCompactLabel: 'Diseño compacto',
   contributeReadyForSubmission: 'Listo para enviar.',
   contributeMenuLabel: 'Secciones de colaboradores',
+  contributeMenuOrganisation: 'Organización',
+  contributeMenuData: 'Datos',
   contributeMenuDungeons: 'Mazmorras',
   contributeMenuMutations: 'Mutaciones semanales',
   contributeMenuSeasons: 'Gestión de temporadas',

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -52,6 +52,8 @@ const esmx = {
   contributeToggleCompactLabel: 'Diseño compacto',
   contributeReadyForSubmission: 'Listo para enviar.',
   contributeMenuLabel: 'Secciones para colaboradores',
+  contributeMenuOrganisation: 'Organización',
+  contributeMenuData: 'Datos',
   contributeMenuDungeons: 'Mazmorras',
   contributeMenuMutations: 'Mutaciones semanales',
   contributeMenuSeasons: 'Gestión de temporadas',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -53,6 +53,8 @@ const fr = {
   contributeToggleCompactLabel: 'Présentation compacte',
   contributeReadyForSubmission: 'Prêt pour envoi.',
   contributeMenuLabel: 'Sections contributeur',
+  contributeMenuOrganisation: 'Organisation',
+  contributeMenuData: 'Données',
   contributeMenuDungeons: 'Donjons',
   contributeMenuMutations: 'Mutations hebdomadaires',
   contributeMenuSeasons: 'Gestion des saisons',

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -52,6 +52,8 @@ const it = {
   contributeToggleCompactLabel: 'Layout compatto',
   contributeReadyForSubmission: 'Pronto per l’invio.',
   contributeMenuLabel: 'Sezioni contributore',
+  contributeMenuOrganisation: 'Organizzazione',
+  contributeMenuData: 'Dati',
   contributeMenuDungeons: 'Spedizioni',
   contributeMenuMutations: 'Mutazioni settimanali',
   contributeMenuSeasons: 'Gestione stagioni',

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -52,6 +52,8 @@ const pl = {
   contributeToggleCompactLabel: 'Kompaktowy układ',
   contributeReadyForSubmission: 'Gotowe do wysłania.',
   contributeMenuLabel: 'Sekcje kontrybutora',
+  contributeMenuOrganisation: 'Organizacja',
+  contributeMenuData: 'Dane',
   contributeMenuDungeons: 'Lochy',
   contributeMenuMutations: 'Mutacje tygodniowe',
   contributeMenuSeasons: 'Zarządzanie sezonami',

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -52,6 +52,8 @@ const pt = {
   contributeToggleCompactLabel: 'Layout compacto',
   contributeReadyForSubmission: 'Pronto para envio.',
   contributeMenuLabel: 'Seções do contribuidor',
+  contributeMenuOrganisation: 'Organização',
+  contributeMenuData: 'Dados',
   contributeMenuDungeons: 'Masmorras',
   contributeMenuMutations: 'Mutações semanais',
   contributeMenuSeasons: 'Gestão de temporadas',


### PR DESCRIPTION
## Summary
- group contributor navigation links into new Organisation and Data dropdown sections
- style dropdown subsections for consistent spacing and add localisation keys for the new headings across all languages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9948dc9ec832cbe43fe49f3767021