### PR TITLE
Display run regions in highlights

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightMetricResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightMetricResponse.java
@@ -13,6 +13,7 @@ public record HighlightMetricResponse(
         Integer week,
         Integer position,
         List<LeaderboardPlayerResponse> players,
+        @JsonProperty("region") String region,
         @JsonProperty("mutation_type_id") String mutationTypeId,
         @JsonProperty("mutation_promotion_id") String mutationPromotionId,
         @JsonProperty("mutation_curse_id") String mutationCurseId) {

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightResponse.java
@@ -11,5 +11,6 @@ public record HighlightResponse(
         String name,
         Map<String, String> names,
         @JsonProperty("player_count") Integer playerCount,
+        @JsonProperty("region") String region,
         @JsonProperty("best_score") HighlightMetricResponse bestScore,
         @JsonProperty("best_time") HighlightMetricResponse bestTime) {}

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1370,6 +1370,13 @@ body[data-theme='light'] .highlight-item {
   position: relative;
 }
 
+.highlight-metric-region {
+  font-size: 0.8rem;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
 body[data-theme='light'] .highlight-metric {
   background: var(--surface-light-soft);
   border-color: var(--border-light);

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1377,6 +1377,15 @@ body[data-theme='light'] .highlight-item {
   opacity: 0.7;
 }
 
+.highlight-metric-mutations {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 body[data-theme='light'] .highlight-metric {
   background: var(--surface-light-soft);
   border-color: var(--border-light);
@@ -1459,8 +1468,8 @@ body[data-theme='light'] .mutation-icon {
 }
 
 .highlight-mutation-icons {
-  align-self: flex-end;
-  margin-top: auto;
+  margin-top: 0;
+  align-self: auto;
 }
 
 .highlight-player {

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1375,15 +1375,17 @@ body[data-theme='light'] .highlight-item {
   letter-spacing: 0.6px;
   text-transform: uppercase;
   opacity: 0.7;
+  margin-right: auto;
 }
 
 .highlight-metric-mutations {
   margin-top: auto;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
   gap: 0.5rem;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 body[data-theme='light'] .highlight-metric {

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -63,6 +63,7 @@ function normaliseMetric(metric) {
   const week = metric.week ?? metric.period ?? metric.season ?? null;
   const players = normalisePlayers(metric.players);
   const mutations = extractMutationIds(metric);
+  const region = extractRegionId(metric);
   const position = toPositiveInteger(
     metric.position ?? metric.rank ?? metric.place ?? metric.standing ?? metric.pos,
   );
@@ -72,6 +73,7 @@ function normaliseMetric(metric) {
     position,
     players,
     mutations,
+    region,
   };
 }
 
@@ -216,6 +218,8 @@ export default function Home() {
               const scoreWeek = score && score.week ? score.week : null;
               const timeWeek = time && time.week ? time.week : null;
               const regionLabel = highlight.region ? translateRegion(t, highlight.region) : '';
+              const scoreRegionLabel = score?.region ? translateRegion(t, score.region) : '';
+              const timeRegionLabel = time?.region ? translateRegion(t, time.region) : '';
               return (
                 <li key={highlight.id} className="highlight-item">
                   <header className="highlight-header">
@@ -223,13 +227,6 @@ export default function Home() {
                       <DungeonIcon dungeonId={highlight.id} />
                       <span>{dungeonName}</span>
                     </h2>
-                    {highlight.playerCount ? (
-                      <span className="highlight-meta">
-                        {typeof t.contributeDungeonExpectedPlayers === 'function'
-                          ? t.contributeDungeonExpectedPlayers(highlight.playerCount)
-                          : `${t.contributeDungeonExpectedPlayers ?? ''} ${highlight.playerCount}`.trim()}
-                      </span>
-                    ) : null}
                   </header>
                   <div className="highlight-metrics">
                     <div className="highlight-metric">
@@ -273,6 +270,9 @@ export default function Home() {
                             );
                           })}
                         </ul>
+                      ) : null}
+                      {scoreRegionLabel ? (
+                        <span className="highlight-metric-region">{scoreRegionLabel}</span>
                       ) : null}
                       <MutationIconList
                         {...(score?.mutations ?? {})}
@@ -320,6 +320,9 @@ export default function Home() {
                             );
                           })}
                         </ul>
+                      ) : null}
+                      {timeRegionLabel ? (
+                        <span className="highlight-metric-region">{timeRegionLabel}</span>
                       ) : null}
                       <MutationIconList
                         {...(time?.mutations ?? {})}

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -9,7 +9,7 @@ import {
   sortDungeons,
   toPositiveInteger,
 } from '../dungeons.js';
-import { extractMutationIds } from '../mutations.js';
+import { extractMutationIds, hasMutationIds } from '../mutations.js';
 import { capitaliseWords } from '../text.js';
 import { formatPlayerLinkProps } from '../playerNames.js';
 import { extractRegionId, translateRegion } from '../regions.js';
@@ -220,6 +220,8 @@ export default function Home() {
               const regionLabel = highlight.region ? translateRegion(t, highlight.region) : '';
               const scoreRegionLabel = score?.region ? translateRegion(t, score.region) : '';
               const timeRegionLabel = time?.region ? translateRegion(t, time.region) : '';
+              const hasScoreMutations = hasMutationIds(score?.mutations);
+              const hasTimeMutations = hasMutationIds(time?.mutations);
               return (
                 <li key={highlight.id} className="highlight-item">
                   <header className="highlight-header">
@@ -271,13 +273,19 @@ export default function Home() {
                           })}
                         </ul>
                       ) : null}
-                      {scoreRegionLabel ? (
-                        <span className="highlight-metric-region">{scoreRegionLabel}</span>
+                      {scoreRegionLabel || hasScoreMutations ? (
+                        <div className="highlight-metric-mutations">
+                          {scoreRegionLabel ? (
+                            <span className="highlight-metric-region">{scoreRegionLabel}</span>
+                          ) : null}
+                          {hasScoreMutations ? (
+                            <MutationIconList
+                              {...(score?.mutations ?? {})}
+                              className="highlight-mutation-icons"
+                            />
+                          ) : null}
+                        </div>
                       ) : null}
-                      <MutationIconList
-                        {...(score?.mutations ?? {})}
-                        className="highlight-mutation-icons"
-                      />
                     </div>
                     <div className="highlight-metric">
                       <RankBadge
@@ -321,13 +329,19 @@ export default function Home() {
                           })}
                         </ul>
                       ) : null}
-                      {timeRegionLabel ? (
-                        <span className="highlight-metric-region">{timeRegionLabel}</span>
+                      {timeRegionLabel || hasTimeMutations ? (
+                        <div className="highlight-metric-mutations">
+                          {timeRegionLabel ? (
+                            <span className="highlight-metric-region">{timeRegionLabel}</span>
+                          ) : null}
+                          {hasTimeMutations ? (
+                            <MutationIconList
+                              {...(time?.mutations ?? {})}
+                              className="highlight-mutation-icons"
+                            />
+                          ) : null}
+                        </div>
                       ) : null}
-                      <MutationIconList
-                        {...(time?.mutations ?? {})}
-                        className="highlight-mutation-icons"
-                      />
                     </div>
                   </div>
                   {regionLabel ? (


### PR DESCRIPTION
## Summary
- include region metadata when normalising highlight metrics
- show the run region for each highlight score and time group and remove the expected players label
- add styling for the per-metric region badge

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9a3061574832c999b2a18067f6e2a