### PR TITLE
Ensure season selector remains accessible when leaderboard is empty

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/LeaderboardResource.java
@@ -46,7 +46,8 @@ public class LeaderboardResource {
             @QueryParam("mutationType") List<String> mutationTypeIds,
             @QueryParam("mutationPromotion") List<String> mutationPromotionIds,
             @QueryParam("mutationCurse") List<String> mutationCurseIds,
-            @QueryParam("region") List<String> regionIds) {
+            @QueryParam("region") List<String> regionIds,
+            @QueryParam("seasonId") Integer seasonId) {
         if (dungeonId == null) {
             return Response.status(Status.BAD_REQUEST)
                     .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
@@ -59,7 +60,8 @@ public class LeaderboardResource {
                 mutationTypeIds,
                 mutationPromotionIds,
                 mutationCurseIds,
-                regionIds);
+                regionIds,
+                seasonId);
         return Response.ok(response).build();
     }
 
@@ -70,14 +72,15 @@ public class LeaderboardResource {
             @QueryParam("mutationType") List<String> mutationTypeIds,
             @QueryParam("mutationPromotion") List<String> mutationPromotionIds,
             @QueryParam("mutationCurse") List<String> mutationCurseIds,
-            @QueryParam("region") List<String> regionIds) {
+            @QueryParam("region") List<String> regionIds,
+            @QueryParam("seasonId") Integer seasonId) {
         if (dungeonId == null) {
             return Response.status(Status.BAD_REQUEST)
                     .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
                     .build();
         }
         LeaderboardChartResponse response = leaderboardService.getScoreChartData(
-                dungeonId, mutationTypeIds, mutationPromotionIds, mutationCurseIds, regionIds);
+                dungeonId, mutationTypeIds, mutationPromotionIds, mutationCurseIds, regionIds, seasonId);
         return Response.ok(response).build();
     }
 
@@ -90,7 +93,8 @@ public class LeaderboardResource {
             @QueryParam("mutationType") List<String> mutationTypeIds,
             @QueryParam("mutationPromotion") List<String> mutationPromotionIds,
             @QueryParam("mutationCurse") List<String> mutationCurseIds,
-            @QueryParam("region") List<String> regionIds) {
+            @QueryParam("region") List<String> regionIds,
+            @QueryParam("seasonId") Integer seasonId) {
         if (dungeonId == null) {
             return Response.status(Status.BAD_REQUEST)
                     .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
@@ -103,7 +107,8 @@ public class LeaderboardResource {
                 mutationTypeIds,
                 mutationPromotionIds,
                 mutationCurseIds,
-                regionIds);
+                regionIds,
+                seasonId);
         return Response.ok(response).build();
     }
 
@@ -114,14 +119,15 @@ public class LeaderboardResource {
             @QueryParam("mutationType") List<String> mutationTypeIds,
             @QueryParam("mutationPromotion") List<String> mutationPromotionIds,
             @QueryParam("mutationCurse") List<String> mutationCurseIds,
-            @QueryParam("region") List<String> regionIds) {
+            @QueryParam("region") List<String> regionIds,
+            @QueryParam("seasonId") Integer seasonId) {
         if (dungeonId == null) {
             return Response.status(Status.BAD_REQUEST)
                     .entity(new ApiMessageResponse("dungeonId query parameter is required", null))
                     .build();
         }
         LeaderboardChartResponse response = leaderboardService.getTimeChartData(
-                dungeonId, mutationTypeIds, mutationPromotionIds, mutationCurseIds, regionIds);
+                dungeonId, mutationTypeIds, mutationPromotionIds, mutationCurseIds, regionIds, seasonId);
         return Response.ok(response).build();
     }
 
@@ -134,9 +140,10 @@ public class LeaderboardResource {
 
     @GET
     @Path("/individual")
-    public Response getIndividualRanking(@QueryParam("mode") String modeParam) {
+    public Response getIndividualRanking(
+            @QueryParam("mode") String modeParam, @QueryParam("seasonId") Integer seasonId) {
         IndividualRankingService.Mode mode = IndividualRankingService.Mode.fromQuery(modeParam);
-        List<IndividualRankingEntryResponse> entries = individualRankingService.getRanking(mode);
+        List<IndividualRankingEntryResponse> entries = individualRankingService.getRanking(mode, seasonId);
         return Response.ok(entries).build();
     }
 

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/PlayerResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/PlayerResource.java
@@ -67,8 +67,9 @@ public class PlayerResource {
 
     @GET
     @Path("/{playerId}")
-    public Response getProfile(@PathParam("playerId") Long playerId) {
-        Optional<PlayerProfileResponse> profile = playerProfileService.getProfile(playerId);
+    public Response getProfile(
+            @PathParam("playerId") Long playerId, @QueryParam("seasonId") Integer seasonId) {
+        Optional<PlayerProfileResponse> profile = playerProfileService.getProfile(playerId, seasonId);
         if (profile.isEmpty()) {
             return Response.status(Status.NOT_FOUND)
                     .entity(new ApiMessageResponse("player not found", null))

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/SeasonResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/SeasonResource.java
@@ -1,0 +1,31 @@
+package com.opyruso.nwleaderboard;
+
+import com.opyruso.nwleaderboard.dto.SeasonResponse;
+import com.opyruso.nwleaderboard.repository.SeasonRepository;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Resource exposing public season information. */
+@Path("/seasons")
+@Produces(MediaType.APPLICATION_JSON)
+public class SeasonResource {
+
+    @Inject
+    SeasonRepository seasonRepository;
+
+    @GET
+    public Response listSeasons() {
+        List<SeasonResponse> seasons = seasonRepository.listAllOrderByDateBeginDesc().stream()
+                .filter(season -> season != null && season.getId() != null)
+                .map(season -> new SeasonResponse(season.getId(), season.getDateBegin(), season.getDateEnd()))
+                .collect(Collectors.toList());
+        return Response.ok(seasons).build();
+    }
+}
+

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SeasonResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/SeasonResponse.java
@@ -1,0 +1,9 @@
+package com.opyruso.nwleaderboard.dto;
+
+import java.time.LocalDate;
+
+/**
+ * Public representation of a gameplay season.
+ */
+public record SeasonResponse(Integer id, LocalDate dateBegin, LocalDate dateEnd) {}
+

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
@@ -198,31 +198,42 @@ public class RunScoreRepository implements PanacheRepository<RunScore> {
      * @param playerId identifier of the player
      * @return list of runs sorted by score descending and week descending
      */
-    public List<RunScore> listBestByPlayer(Long playerId) {
-        if (playerId == null) {
+    public List<RunScore> listBestByPlayer(Long playerId, Collection<Integer> weeks) {
+        if (playerId == null || (weeks != null && weeks.isEmpty())) {
             return List.of();
         }
-        return find(
-                        "SELECT DISTINCT run FROM RunScorePlayer rsp "
-                                + "JOIN rsp.runScore run "
-                                + "JOIN FETCH run.dungeon dungeon "
-                                + "WHERE rsp.player.id = ?1 "
-                                + "ORDER BY run.score DESC, run.week DESC, run.id ASC",
-                        playerId)
-                .list();
+        StringBuilder jpql = new StringBuilder(
+                "SELECT DISTINCT run FROM RunScorePlayer rsp "
+                        + "JOIN rsp.runScore run "
+                        + "JOIN FETCH run.dungeon dungeon "
+                        + "WHERE rsp.player.id = :playerId");
+        Parameters parameters = Parameters.with("playerId", playerId);
+        if (weeks != null && !weeks.isEmpty()) {
+            jpql.append(" AND run.week IN :weeks");
+            parameters = parameters.and("weeks", weeks);
+        }
+        jpql.append(" ORDER BY run.score DESC, run.week DESC, run.id ASC");
+        return find(jpql.toString(), parameters).list();
     }
 
     /** Returns the lowest score recorded for each provided dungeon identifier. */
-    public Map<Long, Integer> findMinimumScoresByDungeonIds(Collection<Long> dungeonIds) {
-        if (dungeonIds == null || dungeonIds.isEmpty()) {
+    public Map<Long, Integer> findMinimumScoresByDungeonIds(
+            Collection<Long> dungeonIds, Collection<Integer> weeks) {
+        if (dungeonIds == null || dungeonIds.isEmpty() || (weeks != null && weeks.isEmpty())) {
             return Map.of();
         }
-        List<Object[]> rows = getEntityManager()
-                .createQuery(
-                        "SELECT run.dungeon.id, MIN(run.score) FROM RunScore run WHERE run.dungeon.id IN ?1 GROUP BY run.dungeon.id",
-                        Object[].class)
-                .setParameter(1, dungeonIds)
-                .getResultList();
+        StringBuilder query = new StringBuilder(
+                "SELECT run.dungeon.id, MIN(run.score) FROM RunScore run WHERE run.dungeon.id IN :dungeons");
+        if (weeks != null && !weeks.isEmpty()) {
+            query.append(" AND run.week IN :weeks");
+        }
+        query.append(" GROUP BY run.dungeon.id");
+        var typedQuery = getEntityManager().createQuery(query.toString(), Object[].class);
+        typedQuery.setParameter("dungeons", dungeonIds);
+        if (weeks != null && !weeks.isEmpty()) {
+            typedQuery.setParameter("weeks", weeks);
+        }
+        List<Object[]> rows = typedQuery.getResultList();
         Map<Long, Integer> result = new HashMap<>();
         for (Object[] row : rows) {
             if (row == null || row.length < 2) {
@@ -239,16 +250,23 @@ public class RunScoreRepository implements PanacheRepository<RunScore> {
     }
 
     /** Returns the highest score recorded for each provided dungeon identifier. */
-    public Map<Long, Integer> findMaximumScoresByDungeonIds(Collection<Long> dungeonIds) {
-        if (dungeonIds == null || dungeonIds.isEmpty()) {
+    public Map<Long, Integer> findMaximumScoresByDungeonIds(
+            Collection<Long> dungeonIds, Collection<Integer> weeks) {
+        if (dungeonIds == null || dungeonIds.isEmpty() || (weeks != null && weeks.isEmpty())) {
             return Map.of();
         }
-        List<Object[]> rows = getEntityManager()
-                .createQuery(
-                        "SELECT run.dungeon.id, MAX(run.score) FROM RunScore run WHERE run.dungeon.id IN ?1 GROUP BY run.dungeon.id",
-                        Object[].class)
-                .setParameter(1, dungeonIds)
-                .getResultList();
+        StringBuilder query = new StringBuilder(
+                "SELECT run.dungeon.id, MAX(run.score) FROM RunScore run WHERE run.dungeon.id IN :dungeons");
+        if (weeks != null && !weeks.isEmpty()) {
+            query.append(" AND run.week IN :weeks");
+        }
+        query.append(" GROUP BY run.dungeon.id");
+        var typedQuery = getEntityManager().createQuery(query.toString(), Object[].class);
+        typedQuery.setParameter("dungeons", dungeonIds);
+        if (weeks != null && !weeks.isEmpty()) {
+            typedQuery.setParameter("weeks", weeks);
+        }
+        List<Object[]> rows = typedQuery.getResultList();
         Map<Long, Integer> result = new HashMap<>();
         for (Object[] row : rows) {
             if (row == null || row.length < 2) {

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunTimeRepository.java
@@ -198,31 +198,42 @@ public class RunTimeRepository implements PanacheRepository<RunTime> {
      * @param playerId identifier of the player
      * @return list of runs sorted by duration ascending and week descending
      */
-    public List<RunTime> listBestByPlayer(Long playerId) {
-        if (playerId == null) {
+    public List<RunTime> listBestByPlayer(Long playerId, Collection<Integer> weeks) {
+        if (playerId == null || (weeks != null && weeks.isEmpty())) {
             return List.of();
         }
-        return find(
-                        "SELECT DISTINCT run FROM RunTimePlayer rtp "
-                                + "JOIN rtp.runTime run "
-                                + "JOIN FETCH run.dungeon dungeon "
-                                + "WHERE rtp.player.id = ?1 "
-                                + "ORDER BY run.timeInSecond ASC, run.week DESC, run.id ASC",
-                        playerId)
-                .list();
+        StringBuilder jpql = new StringBuilder(
+                "SELECT DISTINCT run FROM RunTimePlayer rtp "
+                        + "JOIN rtp.runTime run "
+                        + "JOIN FETCH run.dungeon dungeon "
+                        + "WHERE rtp.player.id = :playerId");
+        Parameters parameters = Parameters.with("playerId", playerId);
+        if (weeks != null && !weeks.isEmpty()) {
+            jpql.append(" AND run.week IN :weeks");
+            parameters = parameters.and("weeks", weeks);
+        }
+        jpql.append(" ORDER BY run.timeInSecond ASC, run.week DESC, run.id ASC");
+        return find(jpql.toString(), parameters).list();
     }
 
     /** Returns the fastest time recorded for each provided dungeon identifier. */
-    public Map<Long, Integer> findMinimumTimesByDungeonIds(Collection<Long> dungeonIds) {
-        if (dungeonIds == null || dungeonIds.isEmpty()) {
+    public Map<Long, Integer> findMinimumTimesByDungeonIds(
+            Collection<Long> dungeonIds, Collection<Integer> weeks) {
+        if (dungeonIds == null || dungeonIds.isEmpty() || (weeks != null && weeks.isEmpty())) {
             return Map.of();
         }
-        List<Object[]> rows = getEntityManager()
-                .createQuery(
-                        "SELECT run.dungeon.id, MIN(run.timeInSecond) FROM RunTime run WHERE run.dungeon.id IN ?1 GROUP BY run.dungeon.id",
-                        Object[].class)
-                .setParameter(1, dungeonIds)
-                .getResultList();
+        StringBuilder query = new StringBuilder(
+                "SELECT run.dungeon.id, MIN(run.timeInSecond) FROM RunTime run WHERE run.dungeon.id IN :dungeons");
+        if (weeks != null && !weeks.isEmpty()) {
+            query.append(" AND run.week IN :weeks");
+        }
+        query.append(" GROUP BY run.dungeon.id");
+        var typedQuery = getEntityManager().createQuery(query.toString(), Object[].class);
+        typedQuery.setParameter("dungeons", dungeonIds);
+        if (weeks != null && !weeks.isEmpty()) {
+            typedQuery.setParameter("weeks", weeks);
+        }
+        List<Object[]> rows = typedQuery.getResultList();
         Map<Long, Integer> result = new HashMap<>();
         for (Object[] row : rows) {
             if (row == null || row.length < 2) {
@@ -239,16 +250,23 @@ public class RunTimeRepository implements PanacheRepository<RunTime> {
     }
 
     /** Returns the slowest time recorded for each provided dungeon identifier. */
-    public Map<Long, Integer> findMaximumTimesByDungeonIds(Collection<Long> dungeonIds) {
-        if (dungeonIds == null || dungeonIds.isEmpty()) {
+    public Map<Long, Integer> findMaximumTimesByDungeonIds(
+            Collection<Long> dungeonIds, Collection<Integer> weeks) {
+        if (dungeonIds == null || dungeonIds.isEmpty() || (weeks != null && weeks.isEmpty())) {
             return Map.of();
         }
-        List<Object[]> rows = getEntityManager()
-                .createQuery(
-                        "SELECT run.dungeon.id, MAX(run.timeInSecond) FROM RunTime run WHERE run.dungeon.id IN ?1 GROUP BY run.dungeon.id",
-                        Object[].class)
-                .setParameter(1, dungeonIds)
-                .getResultList();
+        StringBuilder query = new StringBuilder(
+                "SELECT run.dungeon.id, MAX(run.timeInSecond) FROM RunTime run WHERE run.dungeon.id IN :dungeons");
+        if (weeks != null && !weeks.isEmpty()) {
+            query.append(" AND run.week IN :weeks");
+        }
+        query.append(" GROUP BY run.dungeon.id");
+        var typedQuery = getEntityManager().createQuery(query.toString(), Object[].class);
+        typedQuery.setParameter("dungeons", dungeonIds);
+        if (weeks != null && !weeks.isEmpty()) {
+            typedQuery.setParameter("weeks", weeks);
+        }
+        List<Object[]> rows = typedQuery.getResultList();
         Map<Long, Integer> result = new HashMap<>();
         for (Object[] row : rows) {
             if (row == null || row.length < 2) {

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/WeekMutationDungeonRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/WeekMutationDungeonRepository.java
@@ -68,6 +68,25 @@ public class WeekMutationDungeonRepository implements PanacheRepositoryBase<Week
         return query.getResultList();
     }
 
+    public List<Integer> findWeekNumbersBySeason(Long dungeonId, Integer seasonId) {
+        if (seasonId == null) {
+            return List.of();
+        }
+
+        StringBuilder jpql = new StringBuilder(
+                "SELECT DISTINCT w.id.week FROM WeekMutationDungeon w WHERE w.season.id = :seasonId");
+        if (dungeonId != null) {
+            jpql.append(" AND w.dungeon.id = :dungeonId");
+        }
+        jpql.append(" ORDER BY w.id.week DESC");
+
+        var query = getEntityManager().createQuery(jpql.toString(), Integer.class).setParameter("seasonId", seasonId);
+        if (dungeonId != null) {
+            query.setParameter("dungeonId", dungeonId);
+        }
+        return query.getResultList();
+    }
+
     public int assignSeasonToPreviousWeeks(Integer week, Season season) {
         if (week == null || season == null) {
             return 0;

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2488,6 +2488,107 @@ body[data-theme='light'] .player-dungeon-card {
   width: 3rem;
 }
 
+.season-carousel {
+  margin: 1.25rem 0;
+}
+
+.season-carousel-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.season-carousel-track {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.35rem;
+  scroll-snap-type: x proximity;
+}
+
+.season-carousel-track::-webkit-scrollbar {
+  height: 6px;
+}
+
+.season-carousel-track::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+.season-carousel-item {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  padding: 0.55rem 0.95rem;
+  min-width: 5.5rem;
+  text-align: center;
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  scroll-snap-align: start;
+}
+
+.season-carousel-item-label {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.season-carousel-item-range {
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.season-carousel-item.selected {
+  border-color: rgba(124, 92, 255, 0.85);
+  background: rgba(124, 92, 255, 0.2);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.25);
+}
+
+.season-carousel-item:not(.selected):hover,
+.season-carousel-item:not(.selected):focus-visible {
+  outline: none;
+  border-color: rgba(124, 92, 255, 0.6);
+  background: rgba(124, 92, 255, 0.16);
+  box-shadow: 0 0 0 3px rgba(124, 92, 255, 0.18);
+}
+
+.season-carousel-status {
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.season-carousel-status.error {
+  color: #ff9c9c;
+  opacity: 1;
+}
+
+body[data-theme='light'] .season-carousel-item {
+  border-color: rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.05);
+}
+
+body[data-theme='light'] .season-carousel-item.selected {
+  border-color: rgba(94, 53, 177, 0.75);
+  background: rgba(94, 53, 177, 0.18);
+  box-shadow: 0 0 0 3px rgba(94, 53, 177, 0.25);
+}
+
+body[data-theme='light'] .season-carousel-item:not(.selected):hover,
+body[data-theme='light'] .season-carousel-item:not(.selected):focus-visible {
+  border-color: rgba(94, 53, 177, 0.6);
+  background: rgba(94, 53, 177, 0.15);
+}
+
+body[data-theme='light'] .season-carousel-status.error {
+  color: #c62828;
+}
+
 .leaderboard-status {
   margin: 0;
   font-size: 1.05rem;

--- a/nwleaderboard-ui/js/components/SeasonCarousel.js
+++ b/nwleaderboard-ui/js/components/SeasonCarousel.js
@@ -1,0 +1,106 @@
+export default function SeasonCarousel({
+  label,
+  loading = false,
+  error = false,
+  seasons = [],
+  selectedSeasonId = null,
+  onSelect,
+  allLabel,
+  loadingLabel,
+  errorLabel,
+  emptyLabel,
+  formatSeasonLabel,
+  formatSeasonTitle,
+}) {
+  const handleSelect = React.useCallback(
+    (value) => {
+      if (typeof onSelect === 'function') {
+        onSelect(value);
+      }
+    },
+    [onSelect],
+  );
+
+  const activeId = selectedSeasonId === null || selectedSeasonId === undefined
+    ? null
+    : String(selectedSeasonId);
+
+  const renderStatus = (message, isError = false) => (
+    <p className={isError ? 'season-carousel-status error' : 'season-carousel-status'}>{message}</p>
+  );
+
+  let content = null;
+  if (loading) {
+    content = renderStatus(loadingLabel || 'Loading…');
+  } else if (error) {
+    content = renderStatus(errorLabel || 'Unable to load seasons.', true);
+  } else if (!Array.isArray(seasons) || seasons.length === 0) {
+    content = renderStatus(emptyLabel || 'No season available.');
+  } else {
+    content = (
+      <div className="season-carousel-track" role="list">
+        <button
+          type="button"
+          className={activeId === null ? 'season-carousel-item selected' : 'season-carousel-item'}
+          onClick={() => handleSelect(null)}
+          aria-pressed={activeId === null}
+          role="listitem"
+        >
+          <span className="season-carousel-item-label">{allLabel || 'All'}</span>
+        </button>
+        {seasons.map((season) => {
+          if (!season || season.id === null || season.id === undefined) {
+            return null;
+          }
+          const seasonId = String(season.id);
+          const labelText =
+            typeof formatSeasonLabel === 'function' ? formatSeasonLabel(season) : `Season ${seasonId}`;
+          const titleText =
+            typeof formatSeasonTitle === 'function'
+              ? formatSeasonTitle(season)
+              : labelText;
+          const isActive = seasonId === activeId;
+          return (
+            <button
+              key={seasonId}
+              type="button"
+              className={isActive ? 'season-carousel-item selected' : 'season-carousel-item'}
+              onClick={() => handleSelect(seasonId)}
+              aria-pressed={isActive}
+              title={titleText || undefined}
+              role="listitem"
+            >
+              <span className="season-carousel-item-label">{labelText}</span>
+              {season.dateBegin || season.dateEnd ? (
+                <span className="season-carousel-item-range">
+                  {formatSeasonRange(season.dateBegin, season.dateEnd)}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="season-carousel" role="group" aria-label={label || undefined}>
+      {label ? <span className="season-carousel-label">{label}</span> : null}
+      {content}
+    </div>
+  );
+}
+
+function formatSeasonRange(dateBegin, dateEnd) {
+  if (!dateBegin && !dateEnd) {
+    return '';
+  }
+  if (dateBegin && dateEnd) {
+    return `${dateBegin} – ${dateEnd}`;
+  }
+  if (dateBegin) {
+    return `${dateBegin} – ?`;
+  }
+  return `? – ${dateEnd}`;
+}
+

--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -7,6 +7,17 @@ const de = {
   individual: 'Individuell',
   player: 'Spieler',
   players: 'Spieler',
+  seasonSelectorLabel: 'Saison',
+  seasonSelectorAll: 'Alle Saisons',
+  seasonSelectorLoading: 'Saisons werden geladen…',
+  seasonSelectorError: 'Saisonliste konnte nicht geladen werden.',
+  seasonSelectorEmpty: 'Keine Saison verfügbar.',
+  seasonSelectorItemLabel: (id) => `Saison ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const startLabel = start || '—';
+    const endLabel = end || '—';
+    return `Saison ${id} (${startLabel} – ${endLabel})`;
+  },
   login: 'Anmelden',
   logout: 'Abmelden',
   register: 'Konto erstellen',

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -7,6 +7,17 @@ const en = {
   individual: 'Individual',
   player: 'Player',
   players: 'Players',
+  seasonSelectorLabel: 'Season',
+  seasonSelectorAll: 'All seasons',
+  seasonSelectorLoading: 'Loading seasons…',
+  seasonSelectorError: 'Unable to load the season list.',
+  seasonSelectorEmpty: 'No seasons available.',
+  seasonSelectorItemLabel: (id) => `Season ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const startLabel = start || '—';
+    const endLabel = end || '—';
+    return `Season ${id} (${startLabel} – ${endLabel})`;
+  },
   login: 'Log in',
   logout: 'Log out',
   register: 'Create account',

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -7,6 +7,17 @@ const es = {
   individual: 'Individual',
   player: 'Jugador',
   players: 'Jugadores',
+  seasonSelectorLabel: 'Temporada',
+  seasonSelectorAll: 'Todas las temporadas',
+  seasonSelectorLoading: 'Cargando temporadas…',
+  seasonSelectorError: 'No se pudo cargar la lista de temporadas.',
+  seasonSelectorEmpty: 'No hay temporadas disponibles.',
+  seasonSelectorItemLabel: (id) => `Temporada ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const inicio = start || '—';
+    const fin = end || '—';
+    return `Temporada ${id} (${inicio} – ${fin})`;
+  },
   login: 'Iniciar sesión',
   logout: 'Cerrar sesión',
   register: 'Crear cuenta',

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -7,6 +7,17 @@ const esmx = {
   individual: 'Individual',
   player: 'Jugador',
   players: 'Jugadores',
+  seasonSelectorLabel: 'Temporada',
+  seasonSelectorAll: 'Todas las temporadas',
+  seasonSelectorLoading: 'Cargando temporadas…',
+  seasonSelectorError: 'No se pudo cargar la lista de temporadas.',
+  seasonSelectorEmpty: 'No hay temporadas disponibles.',
+  seasonSelectorItemLabel: (id) => `Temporada ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const inicio = start || '—';
+    const fin = end || '—';
+    return `Temporada ${id} (${inicio} – ${fin})`;
+  },
   login: 'Iniciar sesión',
   logout: 'Cerrar sesión',
   register: 'Crear cuenta',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -7,6 +7,17 @@ const fr = {
   individual: 'Individuel',
   player: 'Joueur',
   players: 'Joueurs',
+  seasonSelectorLabel: 'Saison',
+  seasonSelectorAll: 'Toutes les saisons',
+  seasonSelectorLoading: 'Chargement des saisons…',
+  seasonSelectorError: 'Impossible de charger la liste des saisons.',
+  seasonSelectorEmpty: 'Aucune saison disponible.',
+  seasonSelectorItemLabel: (id) => `Saison ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const debut = start || '—';
+    const fin = end || '—';
+    return `Saison ${id} (${debut} – ${fin})`;
+  },
   login: 'Connexion',
   logout: 'Déconnexion',
   register: "Créer un compte",

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -7,6 +7,17 @@ const it = {
   individual: 'Individuale',
   player: 'Giocatore',
   players: 'Giocatori',
+  seasonSelectorLabel: 'Stagione',
+  seasonSelectorAll: 'Tutte le stagioni',
+  seasonSelectorLoading: 'Caricamento stagioni…',
+  seasonSelectorError: 'Impossibile caricare l’elenco delle stagioni.',
+  seasonSelectorEmpty: 'Nessuna stagione disponibile.',
+  seasonSelectorItemLabel: (id) => `Stagione ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const inizio = start || '—';
+    const fine = end || '—';
+    return `Stagione ${id} (${inizio} – ${fine})`;
+  },
   login: 'Accedi',
   logout: 'Disconnetti',
   register: 'Crea account',

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -7,6 +7,17 @@ const pl = {
   individual: 'Indywidualnie',
   player: 'Gracz',
   players: 'Gracze',
+  seasonSelectorLabel: 'Sezon',
+  seasonSelectorAll: 'Wszystkie sezony',
+  seasonSelectorLoading: 'Wczytywanie sezonów…',
+  seasonSelectorError: 'Nie można załadować listy sezonów.',
+  seasonSelectorEmpty: 'Brak dostępnych sezonów.',
+  seasonSelectorItemLabel: (id) => `Sezon ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const startLabel = start || '—';
+    const endLabel = end || '—';
+    return `Sezon ${id} (${startLabel} – ${endLabel})`;
+  },
   login: 'Zaloguj się',
   logout: 'Wyloguj się',
   register: 'Utwórz konto',

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -7,6 +7,17 @@ const pt = {
   individual: 'Individual',
   player: 'Jogador',
   players: 'Jogadores',
+  seasonSelectorLabel: 'Temporada',
+  seasonSelectorAll: 'Todas as temporadas',
+  seasonSelectorLoading: 'Carregando temporadas…',
+  seasonSelectorError: 'Não foi possível carregar a lista de temporadas.',
+  seasonSelectorEmpty: 'Nenhuma temporada disponível.',
+  seasonSelectorItemLabel: (id) => `Temporada ${id}`,
+  seasonSelectorItemTitle: (id, start, end) => {
+    const inicio = start || '—';
+    const fim = end || '—';
+    return `Temporada ${id} (${inicio} – ${fim})`;
+  },
   login: 'Entrar',
   logout: 'Sair',
   register: 'Criar conta',

--- a/nwleaderboard-ui/js/seasons.js
+++ b/nwleaderboard-ui/js/seasons.js
@@ -1,0 +1,30 @@
+export function normaliseSeason(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const idValue = Number(entry.id ?? entry.season_id ?? entry.seasonId);
+  const id = Number.isFinite(idValue) ? idValue : null;
+  const dateBegin = entry.dateBegin ?? entry.date_begin ?? entry.startDate ?? null;
+  const dateEnd = entry.dateEnd ?? entry.date_end ?? entry.endDate ?? null;
+  if (id === null) {
+    return null;
+  }
+  return { id, dateBegin: dateBegin || null, dateEnd: dateEnd || null };
+}
+
+export function sortSeasons(seasons) {
+  if (!Array.isArray(seasons) || seasons.length === 0) {
+    return [];
+  }
+  const items = seasons
+    .map((season) => normaliseSeason(season))
+    .filter((season) => season && season.id !== null);
+  items.sort((left, right) => {
+    if (left.dateBegin && right.dateBegin && left.dateBegin !== right.dateBegin) {
+      return right.dateBegin.localeCompare(left.dateBegin);
+    }
+    return right.id - left.id;
+  });
+  return items;
+}
+


### PR DESCRIPTION
## Summary
- always render the season carousel on score/time leaderboards so the selector stays available during loading, error, and empty states
- reuse a shared SeasonCarousel instance to keep its placement consistent below the chart when data is available

## Testing
- npm --prefix nwleaderboard-ui run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a592f5b0832ca994caa5ec159a1d