### PR TITLE
Revise leaderboard filter layouts

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2826,21 +2826,34 @@ body[data-theme='light'] .dungeon-button.active .dungeon-button-icon {
   gap: 0.75rem;
 }
 
+
 .region-filter-list {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 0.6rem;
 }
 
 .region-filter-button {
-  width: 100%;
-  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 0.75rem;
+  flex: 1 1 calc(50% - 0.3rem);
+  max-width: calc(50% - 0.3rem);
   border-radius: 10px;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(148, 163, 184, 0.12);
   color: inherit;
   cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  text-align: center;
   transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.region-filter-button-code {
+  pointer-events: none;
 }
 
 .region-filter-button:hover,
@@ -2867,6 +2880,130 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   background: rgba(124, 92, 255, 0.18);
   border-color: rgba(124, 92, 255, 0.5);
   box-shadow: 0 6px 18px rgba(124, 92, 255, 0.2);
+}
+
+.dungeon-selector-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dungeon-selected-display {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(124, 92, 255, 0.4);
+  background: rgba(124, 92, 255, 0.12);
+  box-shadow: 0 12px 28px rgba(124, 92, 255, 0.28);
+}
+
+.dungeon-selected-icon {
+  width: auto;
+  height: 2.5rem;
+  flex-shrink: 0;
+  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.35));
+}
+
+.dungeon-selected-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dungeon-selected-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dungeon-selected-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.dungeon-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.dungeon-grid-button {
+  flex: 1 1 calc(25% - 0.75rem);
+  max-width: calc(25% - 0.75rem);
+  min-width: 3.25rem;
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.dungeon-grid-button-icon {
+  width: 2.2rem;
+  height: 2.2rem;
+  filter: drop-shadow(0 4px 8px rgba(15, 23, 42, 0.3));
+}
+
+.dungeon-grid-button:hover,
+.dungeon-grid-button:focus-visible {
+  outline: none;
+  border-color: rgba(124, 92, 255, 0.55);
+  box-shadow: 0 6px 18px rgba(124, 92, 255, 0.22);
+  transform: translateY(-2px);
+}
+
+.dungeon-grid-button.active,
+.dungeon-grid-button[aria-pressed='true'] {
+  background: rgba(124, 92, 255, 0.2);
+  border-color: rgba(124, 92, 255, 0.55);
+  box-shadow: 0 12px 30px rgba(124, 92, 255, 0.28);
+}
+
+.dungeon-grid-button.active .dungeon-grid-button-icon,
+.dungeon-grid-button[aria-pressed='true'] .dungeon-grid-button-icon {
+  filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.35));
+}
+
+body[data-theme='light'] .dungeon-selected-display {
+  background: rgba(124, 92, 255, 0.16);
+  border-color: rgba(124, 92, 255, 0.45);
+  box-shadow: 0 12px 28px rgba(124, 92, 255, 0.22);
+}
+
+body[data-theme='light'] .dungeon-selected-label {
+  color: rgba(71, 85, 105, 0.8);
+}
+
+body[data-theme='light'] .dungeon-grid-button {
+  background: rgba(148, 163, 184, 0.1);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+body[data-theme='light'] .dungeon-grid-button:hover,
+body[data-theme='light'] .dungeon-grid-button:focus-visible {
+  border-color: rgba(124, 92, 255, 0.5);
+  box-shadow: 0 6px 18px rgba(124, 92, 255, 0.24);
+}
+
+body[data-theme='light'] .dungeon-grid-button.active,
+body[data-theme='light'] .dungeon-grid-button[aria-pressed='true'] {
+  background: rgba(124, 92, 255, 0.18);
+  border-color: rgba(124, 92, 255, 0.5);
+  box-shadow: 0 12px 30px rgba(124, 92, 255, 0.24);
+}
+
+body[data-theme='light'] .dungeon-grid-button.active .dungeon-grid-button-icon,
+body[data-theme='light'] .dungeon-grid-button[aria-pressed='true'] .dungeon-grid-button-icon {
+  filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.25));
 }
 
 .mutation-filter-group {

--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -382,6 +382,7 @@ const de = {
   individualScorePointsHeader: 'Score-Punkte',
   individualTimePointsHeader: 'Zeit-Punkte',
   dungeonSelectorTitle: 'Dungeon auswählen',
+  dungeonSelectorCurrent: 'Ausgewählter Dungeon',
   dungeonSelectorEmpty: 'Noch keine Dungeons verfügbar.',
   dungeonSelectorError: 'Dungeons konnten nicht geladen werden. Bitte später versuchen.',
   mutationFilterTitle: 'Nach Mutation filtern',

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -383,6 +383,7 @@ const en = {
   individualScorePointsHeader: 'Score pts',
   individualTimePointsHeader: 'Time pts',
   dungeonSelectorTitle: 'Select a dungeon',
+  dungeonSelectorCurrent: 'Selected dungeon',
   dungeonSelectorEmpty: 'No dungeon available yet.',
   dungeonSelectorError: 'Unable to load dungeons. Please try again later.',
   mutationFilterTitle: 'Filter by mutation',

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -384,6 +384,7 @@ const es = {
   individualScorePointsHeader: 'Pts. puntuación',
   individualTimePointsHeader: 'Pts. tiempo',
   dungeonSelectorTitle: 'Selecciona una mazmorra',
+  dungeonSelectorCurrent: 'Mazmorra seleccionada',
   dungeonSelectorEmpty: 'Todavía no hay mazmorras disponibles.',
   dungeonSelectorError: 'No se pueden cargar las mazmorras. Inténtalo más tarde.',
   mutationFilterTitle: 'Filtrar por mutación',

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -382,6 +382,7 @@ const esmx = {
   individualScorePointsHeader: 'Pts. score',
   individualTimePointsHeader: 'Pts. tiempo',
   dungeonSelectorTitle: 'Selecciona una mazmorra',
+  dungeonSelectorCurrent: 'Mazmorra seleccionada',
   dungeonSelectorEmpty: 'Aún no hay mazmorras disponibles.',
   dungeonSelectorError: 'No se pueden cargar las mazmorras. Intenta después.',
   mutationFilterTitle: 'Filtrar por mutación',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -389,6 +389,7 @@ const fr = {
   individualScorePointsHeader: 'Points score',
   individualTimePointsHeader: 'Points temps',
   dungeonSelectorTitle: 'Sélectionnez un donjon',
+  dungeonSelectorCurrent: 'Donjon sélectionné',
   dungeonSelectorEmpty: 'Aucun donjon disponible pour le moment.',
   dungeonSelectorError: 'Impossible de charger les donjons. Veuillez réessayer plus tard.',
   mutationFilterTitle: 'Filtrer par mutation',

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -382,6 +382,7 @@ const it = {
   individualScorePointsHeader: 'Punti score',
   individualTimePointsHeader: 'Punti tempo',
   dungeonSelectorTitle: 'Seleziona una spedizione',
+  dungeonSelectorCurrent: 'Spedizione selezionata',
   dungeonSelectorEmpty: 'Nessuna spedizione disponibile.',
   dungeonSelectorError: 'Impossibile caricare le spedizioni. Riprova più tardi.',
   mutationFilterTitle: 'Filtra per mutazione',

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -382,6 +382,7 @@ const pl = {
   individualScorePointsHeader: 'Punkty wyniku',
   individualTimePointsHeader: 'Punkty czasu',
   dungeonSelectorTitle: 'Wybierz loch',
+  dungeonSelectorCurrent: 'Wybrany loch',
   dungeonSelectorEmpty: 'Brak dostępnych lochów.',
   dungeonSelectorError: 'Nie można załadować lochów. Spróbuj później.',
   mutationFilterTitle: 'Filtruj mutacje',

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -382,6 +382,7 @@ const pt = {
   individualScorePointsHeader: 'Pts. score',
   individualTimePointsHeader: 'Pts. tempo',
   dungeonSelectorTitle: 'Selecione uma masmorra',
+  dungeonSelectorCurrent: 'Masmorra selecionada',
   dungeonSelectorEmpty: 'Nenhuma masmorra disponível ainda.',
   dungeonSelectorError: 'Não foi possível carregar as masmorras. Tente novamente mais tarde.',
   mutationFilterTitle: 'Filtrar por mutação',


### PR DESCRIPTION
## Summary
- collapse the region filter by default and present region codes in a two-column flex layout with localized tooltips
- redesign the dungeon selector to highlight the current dungeon and list available dungeons in a four-column icon grid
- add supporting translations and styles for the updated sidebar presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6ef07dd0832c92f89fda8078c15f