### PR TITLE
Remove dungeon global region label from highlights

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1373,22 +1373,6 @@ body[data-theme='light'] .highlight-item {
   gap: 1.25rem;
 }
 
-.highlight-footer {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  margin-top: auto;
-  padding-top: 0.5rem;
-}
-
-.highlight-region {
-  font-size: 0.85rem;
-  opacity: 0.75;
-  letter-spacing: 0.6px;
-  text-transform: uppercase;
-  align-self: flex-start;
-}
-
 .highlight-metric {
   display: flex;
   flex-direction: column;

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -217,7 +217,6 @@ export default function Home() {
               const timeValue = time ? formatTime(time.value) : t.highlightNoTime;
               const scoreWeek = score && score.week ? score.week : null;
               const timeWeek = time && time.week ? time.week : null;
-              const regionLabel = highlight.region ? translateRegion(t, highlight.region) : '';
               const scoreRegionLabel = score?.region ? translateRegion(t, score.region) : '';
               const timeRegionLabel = time?.region ? translateRegion(t, time.region) : '';
               const hasScoreMutations = hasMutationIds(score?.mutations);
@@ -344,11 +343,6 @@ export default function Home() {
                       ) : null}
                     </div>
                   </div>
-                  {regionLabel ? (
-                    <div className="highlight-footer">
-                      <span className="highlight-region">{regionLabel}</span>
-                    </div>
-                  ) : null}
                 </li>
               );
             })}


### PR DESCRIPTION
## Summary
- stop showing the global region label on highlight dungeon cards
- remove the unused highlight footer styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da76523ae0832ca12cc79e96be097b