### PR TITLE
Fix contributor stats endpoint routing conflict

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/ContributorResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/ContributorResource.java
@@ -5,7 +5,6 @@ import com.opyruso.nwleaderboard.dto.ContributionExtractionResponseDto;
 import com.opyruso.nwleaderboard.dto.ContributionRunDto;
 import com.opyruso.nwleaderboard.dto.ContributionScanDetailDto;
 import com.opyruso.nwleaderboard.dto.ContributionScanSummaryDto;
-import com.opyruso.nwleaderboard.dto.ContributorWeeklyRunsResponse;
 import com.opyruso.nwleaderboard.dto.UpdateContributionScanRequest;
 import com.opyruso.nwleaderboard.dto.UpdateDungeonHighlightsRequest;
 import com.opyruso.nwleaderboard.dto.RegionResponse;
@@ -14,7 +13,6 @@ import com.opyruso.nwleaderboard.service.ContributorExtractionService;
 import com.opyruso.nwleaderboard.service.ContributorExtractionService.ContributorRequestException;
 import com.opyruso.nwleaderboard.service.ContributorSubmissionService;
 import com.opyruso.nwleaderboard.service.ContributorSubmissionService.ContributorSubmissionException;
-import com.opyruso.nwleaderboard.service.ContributorStatisticsService;
 import com.opyruso.nwleaderboard.service.DungeonService;
 import com.opyruso.nwleaderboard.service.RegionService;
 import com.opyruso.nwleaderboard.service.ScanLeaderboardService;
@@ -65,10 +63,7 @@ public class ContributorResource {
 
     @Inject
     DungeonService dungeonService;
-
-    @Inject
-    ContributorStatisticsService statisticsService;
-
+    
     @Inject
     ScanLeaderboardService scanLeaderboardService;
 
@@ -146,25 +141,6 @@ public class ContributorResource {
             LOG.error("Unable to update highlighted dungeons", e);
             return Response.status(Status.BAD_GATEWAY)
                     .entity(new ApiMessageResponse("Unable to update dungeon highlights", null))
-                    .build();
-        }
-    }
-
-    @GET
-    @Path("/runs/weekly")
-    public Response listRunsByWeek() {
-        if (!hasContributorRole()) {
-            return Response.status(Status.FORBIDDEN)
-                    .entity(new ApiMessageResponse("Contributor role required", null))
-                    .build();
-        }
-        try {
-            List<ContributorWeeklyRunsResponse> summaries = statisticsService.listRunsByWeek();
-            return Response.ok(summaries).build();
-        } catch (Exception e) {
-            LOG.error("Unable to load contributor run statistics", e);
-            return Response.status(Status.BAD_GATEWAY)
-                    .entity(new ApiMessageResponse("Unable to load run statistics", null))
                     .build();
         }
     }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/ContributorRunResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/ContributorRunResource.java
@@ -3,8 +3,10 @@ package com.opyruso.nwleaderboard;
 import com.opyruso.nwleaderboard.dto.ApiMessageResponse;
 import com.opyruso.nwleaderboard.dto.ContributorRunSummaryResponse;
 import com.opyruso.nwleaderboard.dto.ContributorRunUpdateRequest;
+import com.opyruso.nwleaderboard.dto.ContributorWeeklyRunsResponse;
 import com.opyruso.nwleaderboard.service.ContributorRunService;
 import com.opyruso.nwleaderboard.service.ContributorRunService.ContributorRunException;
+import com.opyruso.nwleaderboard.service.ContributorStatisticsService;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
@@ -38,6 +40,9 @@ public class ContributorRunResource {
     ContributorRunService runService;
 
     @Inject
+    ContributorStatisticsService statisticsService;
+
+    @Inject
     SecurityIdentity identity;
 
     @Inject
@@ -66,6 +71,23 @@ public class ContributorRunResource {
             LOG.error("Unable to search runs", e);
             return Response.status(Status.BAD_GATEWAY)
                     .entity(new ApiMessageResponse("Unable to search runs", null))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/weekly")
+    public Response listRunsByWeek() {
+        if (!hasContributorRole()) {
+            return forbidden();
+        }
+        try {
+            List<ContributorWeeklyRunsResponse> summaries = statisticsService.listRunsByWeek();
+            return Response.ok(summaries).build();
+        } catch (Exception e) {
+            LOG.error("Unable to load contributor run statistics", e);
+            return Response.status(Status.BAD_GATEWAY)
+                    .entity(new ApiMessageResponse("Unable to load run statistics", null))
                     .build();
         }
     }


### PR DESCRIPTION
## Summary
- expose the weekly contributor run statistics from ContributorRunResource so /contributor/runs/weekly resolves correctly
- remove the unused statistics dependency from ContributorResource after moving the endpoint

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68da99991364832c84de2d4a9a887942