### PR TITLE
Improve season carousel defaults and persistence

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2541,9 +2541,20 @@ body[data-theme='light'] .player-dungeon-card {
   padding-bottom: 0.35rem;
   scroll-snap-type: x proximity;
   width: 100%;
+  scrollbar-width: none;
+  scrollbar-gutter: stable both-edges;
+}
+
+.season-carousel-track:hover {
+  scrollbar-width: thin;
 }
 
 .season-carousel-track::-webkit-scrollbar {
+  height: 0;
+  transition: height 0.2s ease;
+}
+
+.season-carousel-track:hover::-webkit-scrollbar {
   height: 6px;
 }
 
@@ -2554,11 +2565,11 @@ body[data-theme='light'] .player-dungeon-card {
 
 .season-carousel-item {
   flex: 0 0 auto;
-  border-radius: 999px;
+  border-radius: 10px;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(148, 163, 184, 0.12);
   color: inherit;
-  padding: 0.55rem 0.95rem;
+  padding: 0rem 0.5rem;
   min-width: 5.5rem;
   text-align: center;
   cursor: pointer;
@@ -2573,6 +2584,7 @@ body[data-theme='light'] .player-dungeon-card {
 .season-carousel-item-label {
   font-weight: 600;
   letter-spacing: 0.01em;
+  font-size: 0.8rem;
 }
 
 .season-carousel-item-range {

--- a/nwleaderboard-ui/js/components/SeasonCarousel.js
+++ b/nwleaderboard-ui/js/components/SeasonCarousel.js
@@ -1,5 +1,6 @@
 export default function SeasonCarousel({
   label,
+  ariaLabel,
   loading = false,
   error = false,
   seasons = [],
@@ -12,6 +13,7 @@ export default function SeasonCarousel({
   formatSeasonLabel,
   formatSeasonTitle,
   displayRange = true,
+  hideLabel = false,
 }) {
   const handleSelect = React.useCallback(
     (value) => {
@@ -95,9 +97,11 @@ export default function SeasonCarousel({
     );
   }
 
+  const groupLabel = ariaLabel || label;
+
   return (
-    <div className="season-carousel" role="group" aria-label={label || undefined}>
-      {label ? <span className="season-carousel-label">{label}</span> : null}
+    <div className="season-carousel" role="group" aria-label={groupLabel || undefined}>
+      {label && !hideLabel ? <span className="season-carousel-label">{label}</span> : null}
       {content}
     </div>
   );

--- a/nwleaderboard-ui/js/seasons.js
+++ b/nwleaderboard-ui/js/seasons.js
@@ -1,3 +1,79 @@
+export const SEASON_STORAGE_PREFIX = 'nwleaderboard:season:';
+
+function parseSeasonBoundary(value, endOfDay = false) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const hasTimeComponent = /[tT]/.test(trimmed);
+  const isoString = hasTimeComponent ? trimmed : `${trimmed}T00:00:00Z`;
+  const parsed = Date.parse(isoString);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+  if (!endOfDay) {
+    return parsed;
+  }
+  if (hasTimeComponent) {
+    const date = new Date(parsed);
+    date.setHours(23, 59, 59, 999);
+    return date.getTime();
+  }
+  const oneDay = 24 * 60 * 60 * 1000;
+  return parsed + oneDay - 1;
+}
+
+function normaliseStoredSeasonId(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  return undefined;
+}
+
+export function loadStoredSeasonId(storageKey) {
+  if (!storageKey || typeof window === 'undefined' || !window.localStorage) {
+    return undefined;
+  }
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (raw === null) {
+      return undefined;
+    }
+    return normaliseStoredSeasonId(JSON.parse(raw));
+  } catch (error) {
+    return undefined;
+  }
+}
+
+export function saveStoredSeasonId(storageKey, seasonId) {
+  if (!storageKey || typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    if (seasonId === undefined) {
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+    const payload = seasonId === null ? null : String(seasonId);
+    window.localStorage.setItem(storageKey, JSON.stringify(payload));
+  } catch (error) {
+    // ignore storage errors
+  }
+}
+
 export function normaliseSeason(entry) {
   if (!entry || typeof entry !== 'object') {
     return null;
@@ -28,3 +104,28 @@ export function sortSeasons(seasons) {
   return items;
 }
 
+export function findCurrentSeasonId(seasons, referenceDate = new Date()) {
+  if (!Array.isArray(seasons) || seasons.length === 0) {
+    return null;
+  }
+  const currentDate = referenceDate instanceof Date ? referenceDate : new Date(referenceDate);
+  const currentTime = currentDate.getTime();
+  if (!Number.isFinite(currentTime)) {
+    return null;
+  }
+  for (const season of seasons) {
+    if (!season || season.id === undefined || season.id === null) {
+      continue;
+    }
+    const startTime = parseSeasonBoundary(season.dateBegin, false);
+    const endTime = parseSeasonBoundary(season.dateEnd, true);
+    if (startTime !== null && Number.isFinite(startTime) && currentTime < startTime) {
+      continue;
+    }
+    if (endTime !== null && Number.isFinite(endTime) && currentTime > endTime) {
+      continue;
+    }
+    return String(season.id);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add season storage utilities and default the picker to the current season when available
- persist season, dungeon, and region selections between visits on leaderboard and profile views
- refresh carousel styling, hiding the label and scrollbar until hover per new design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9fd8e49c832c8aa7d1600dd2390d