### PR TITLE
Update contributor stats headers to use region codes

### DIFF
--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -148,6 +148,8 @@ const de = {
   contributeStatsError: 'Run-Statistiken konnten nicht geladen werden.',
   contributeStatsEmpty: 'Es wurden noch keine Runs erfasst.',
   contributeStatsWeek: 'Woche',
+  contributeStatsScoreShort: 'Score',
+  contributeStatsTimeShort: 'Zeit',
   contributeStatsScoreRuns: 'Score-Runs',
   contributeStatsScoreRunsRegion: (region) => `${region} – Score-Runs`,
   contributeStatsTimeRuns: 'Zeit-Runs',

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -147,6 +147,8 @@ const en = {
   contributeStatsError: 'Unable to load run statistics.',
   contributeStatsEmpty: 'No runs recorded yet.',
   contributeStatsWeek: 'Week',
+  contributeStatsScoreShort: 'Score',
+  contributeStatsTimeShort: 'Time',
   contributeStatsScoreRuns: 'Score runs',
   contributeStatsScoreRunsRegion: (region) => `${region} – Score runs`,
   contributeStatsTimeRuns: 'Time runs',

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -149,6 +149,8 @@ const es = {
   contributeStatsError: 'No se pueden cargar las estadísticas de partidas.',
   contributeStatsEmpty: 'Todavía no hay partidas registradas.',
   contributeStatsWeek: 'Semana',
+  contributeStatsScoreShort: 'Puntuación',
+  contributeStatsTimeShort: 'Tiempo',
   contributeStatsScoreRuns: 'Partidas de puntuación',
   contributeStatsScoreRunsRegion: (region) => `${region} – Partidas de puntuación`,
   contributeStatsTimeRuns: 'Partidas de tiempo',

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -148,6 +148,8 @@ const esmx = {
   contributeStatsError: 'No se pueden cargar las estadísticas de runs.',
   contributeStatsEmpty: 'Aún no hay runs registradas.',
   contributeStatsWeek: 'Semana',
+  contributeStatsScoreShort: 'Puntuación',
+  contributeStatsTimeShort: 'Tiempo',
   contributeStatsScoreRuns: 'Runs de score',
   contributeStatsScoreRunsRegion: (region) => `${region} – Runs de score`,
   contributeStatsTimeRuns: 'Runs de tiempo',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -148,6 +148,8 @@ const fr = {
   contributeStatsError: 'Impossible de charger les statistiques des runs.',
   contributeStatsEmpty: 'Aucun run enregistré pour le moment.',
   contributeStatsWeek: 'Semaine',
+  contributeStatsScoreShort: 'Score',
+  contributeStatsTimeShort: 'Temps',
   contributeStatsScoreRuns: 'Runs score',
   contributeStatsScoreRunsRegion: (region) => `${region} – Runs score`,
   contributeStatsTimeRuns: 'Runs temps',

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -148,6 +148,8 @@ const it = {
   contributeStatsError: 'Impossibile caricare le statistiche delle run.',
   contributeStatsEmpty: 'Non ci sono ancora run registrate.',
   contributeStatsWeek: 'Settimana',
+  contributeStatsScoreShort: 'Punteggio',
+  contributeStatsTimeShort: 'Tempo',
   contributeStatsScoreRuns: 'Run punteggio',
   contributeStatsScoreRunsRegion: (region) => `${region} – Run punteggio`,
   contributeStatsTimeRuns: 'Run tempo',

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -148,6 +148,8 @@ const pl = {
   contributeStatsError: 'Nie można załadować statystyk run.',
   contributeStatsEmpty: 'Nie zarejestrowano jeszcze run.',
   contributeStatsWeek: 'Tydzień',
+  contributeStatsScoreShort: 'Wynik',
+  contributeStatsTimeShort: 'Czas',
   contributeStatsScoreRuns: 'Runy wynikowe',
   contributeStatsScoreRunsRegion: (region) => `${region} – Runy wynikowe`,
   contributeStatsTimeRuns: 'Runy czasowe',

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -148,6 +148,8 @@ const pt = {
   contributeStatsError: 'Não foi possível carregar as estatísticas das runs.',
   contributeStatsEmpty: 'Ainda não há runs registradas.',
   contributeStatsWeek: 'Semana',
+  contributeStatsScoreShort: 'Pontuação',
+  contributeStatsTimeShort: 'Tempo',
   contributeStatsScoreRuns: 'Runs de score',
   contributeStatsScoreRunsRegion: (region) => `${region} – Runs de score`,
   contributeStatsTimeRuns: 'Runs de tempo',

--- a/nwleaderboard-ui/js/pages/ContributeStats.js
+++ b/nwleaderboard-ui/js/pages/ContributeStats.js
@@ -1,5 +1,5 @@
 import { LangContext } from '../i18n.js';
-import { normaliseRegionList, translateRegion } from '../regions.js';
+import { normaliseRegionList } from '../regions.js';
 
 const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
 
@@ -175,19 +175,12 @@ export default function ContributeStats() {
                 <tr>
                   <th scope="col">{t.contributeStatsWeek}</th>
                   {regionColumns.map((region) => {
-                    const regionName = translateRegion(t, region);
-                    const scoreHeader =
-                      typeof t.contributeStatsScoreRunsRegion === 'function'
-                        ? t.contributeStatsScoreRunsRegion(regionName)
-                        : `${regionName} ${t.contributeStatsScoreRuns}`;
-                    const timeHeader =
-                      typeof t.contributeStatsTimeRunsRegion === 'function'
-                        ? t.contributeStatsTimeRunsRegion(regionName)
-                        : `${regionName} ${t.contributeStatsTimeRuns}`;
+                    const scoreLabel = t.contributeStatsScoreShort || 'Score';
+                    const timeLabel = t.contributeStatsTimeShort || 'Time';
                     return (
                       <React.Fragment key={region}>
-                        <th scope="col">{scoreHeader}</th>
-                        <th scope="col">{timeHeader}</th>
+                        <th scope="col">{`${region} ${scoreLabel}`}</th>
+                        <th scope="col">{`${region} ${timeLabel}`}</th>
                       </React.Fragment>
                     );
                   })}


### PR DESCRIPTION
## Summary
- show region codes with score and time headers in the contributor stats table
- add localized short labels for the score and time column headers

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68daa5fc4254832caca2b1418d9f81b8