### PR TITLE
Style contribute players validation buttons

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -3747,6 +3747,7 @@ body[data-theme='light'] .contribute-compact-table tbody td {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  margin-top: 0;
 }
 
 .contribute-players-visibility {

--- a/nwleaderboard-ui/js/pages/ContributePlayers.js
+++ b/nwleaderboard-ui/js/pages/ContributePlayers.js
@@ -469,10 +469,9 @@ export default function ContributePlayers() {
           'Manage player names and validity for leaderboard submissions.'}
       </p>
       <div className="contribute-players-controls">
-        <div className="contribute-players-bulk-actions">
+        <div className="contribute-players-bulk-actions form-actions">
           <button
             type="button"
-            className="button button-secondary"
             onClick={handleValidateEligiblePlayers}
             disabled={disableAutoButton}
           >
@@ -480,7 +479,6 @@ export default function ContributePlayers() {
           </button>
           <button
             type="button"
-            className="button button-secondary"
             onClick={handleValidateAllPendingPlayers}
             disabled={disableAllButton}
           >


### PR DESCRIPTION
## Summary
- align the Contribute > Players bulk validation buttons with the default button styling
- reset the bulk action container spacing so it works with the shared form action styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daae847204832cbdf8408310036b0f