### PR TITLE
Display scan thumbnail preview on contributor validation page

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -3349,6 +3349,59 @@ body[data-theme='light'] .contribute-file-item--error {
   flex-wrap: wrap;
 }
 
+.contribute-results-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.contribute-results-picture-button {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.contribute-results-picture-thumb {
+  display: block;
+  width: 128px;
+  height: 72px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  object-fit: cover;
+}
+
+body[data-theme='light'] .contribute-results-picture-thumb {
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
+.contribute-picture-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  cursor: zoom-out;
+  z-index: 1000;
+}
+
+.contribute-picture-modal-image {
+  max-width: min(1200px, 90vw);
+  max-height: 90vh;
+  width: auto;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  pointer-events: none;
+}
+
+body[data-theme='light'] .contribute-picture-modal-image {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
 .contribute-results-actions {
   display: flex;
   align-items: center;

--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -46,6 +46,7 @@ const de = {
   contributeExtracting: 'Extrahiere…',
   contributeClear: 'Auswahl löschen',
   contributeResultsTitle: 'Erkannte Runs',
+  contributeOriginalScreenshotAlt: 'Original-Screenshot',
   contributeRescan: 'Erneut scannen erzwingen',
   contributeRescanning: 'Erneuter Scan…',
   contributeRescanPrompt: 'Gib den vertikalen Versatz (Pixel) an:',

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -46,6 +46,7 @@ const en = {
   contributeExtracting: 'Extracting…',
   contributeClear: 'Clear selection',
   contributeResultsTitle: 'Detected runs',
+  contributeOriginalScreenshotAlt: 'Original screenshot',
   contributeRescan: 'Force re-scan',
   contributeRescanning: 'Re-scanning…',
   contributeRescanPrompt: 'Enter the vertical offset (pixels) to use:',

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -47,6 +47,7 @@ const es = {
   contributeExtracting: 'Extrayendo…',
   contributeClear: 'Limpiar selección',
   contributeResultsTitle: 'Partidas detectadas',
+  contributeOriginalScreenshotAlt: 'Captura original',
   contributeRescan: 'Forzar reescaneo',
   contributeRescanning: 'Reescaneando…',
   contributeRescanPrompt: 'Introduce el desplazamiento vertical (píxeles) que se usará:',

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -46,6 +46,7 @@ const esmx = {
   contributeExtracting: 'Extrayendo…',
   contributeClear: 'Limpiar selección',
   contributeResultsTitle: 'Runs detectadas',
+  contributeOriginalScreenshotAlt: 'Captura original',
   contributeRescan: 'Forzar reescaneo',
   contributeRescanning: 'Reescaneando…',
   contributeRescanPrompt: 'Ingresa el desplazamiento vertical (en píxeles) a utilizar:',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -47,6 +47,7 @@ const fr = {
   contributeExtracting: 'Extraction…',
   contributeClear: 'Effacer la sélection',
   contributeResultsTitle: 'Runs détectés',
+  contributeOriginalScreenshotAlt: 'Capture d’écran originale',
   contributeRescan: 'Re-scanner (offset forcé)',
   contributeRescanning: 'Re-scannage…',
   contributeRescanPrompt: 'Indiquez l\u2019offset vertical (en pixels) à utiliser :',

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -46,6 +46,7 @@ const it = {
   contributeExtracting: 'Estrazione…',
   contributeClear: 'Pulisci selezione',
   contributeResultsTitle: 'Run rilevate',
+  contributeOriginalScreenshotAlt: 'Schermata originale',
   contributeRescan: 'Forza nuova scansione',
   contributeRescanning: 'Nuova scansione…',
   contributeRescanPrompt: 'Inserisci l’offset verticale (in pixel) da utilizzare:',

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -46,6 +46,7 @@ const pl = {
   contributeExtracting: 'Wyodrębnianie…',
   contributeClear: 'Wyczyść wybór',
   contributeResultsTitle: 'Wykryte runy',
+  contributeOriginalScreenshotAlt: 'Oryginalny zrzut ekranu',
   contributeRescan: 'Wymuś ponowne skanowanie',
   contributeRescanning: 'Ponowne skanowanie…',
   contributeRescanPrompt: 'Podaj przesunięcie pionowe (w pikselach):',

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -46,6 +46,7 @@ const pt = {
   contributeExtracting: 'Extraindo…',
   contributeClear: 'Limpar seleção',
   contributeResultsTitle: 'Runs detectadas',
+  contributeOriginalScreenshotAlt: 'Captura original',
   contributeRescan: 'Forçar nova varredura',
   contributeRescanning: 'Nova varredura…',
   contributeRescanPrompt: 'Informe o deslocamento vertical (em pixels):',

--- a/nwleaderboard-ui/js/pages/ContributeValidate.js
+++ b/nwleaderboard-ui/js/pages/ContributeValidate.js
@@ -393,6 +393,7 @@ export default function ContributeValidate() {
   const [rescanning, setRescanning] = React.useState(false);
   const [deletingScan, setDeletingScan] = React.useState(false);
   const [groupOffsets, setGroupOffsets] = React.useState(() => Array(5).fill('0'));
+  const [showPictureModal, setShowPictureModal] = React.useState(false);
 
   const getConfidenceLabel = React.useCallback((confidence) => formatConfidenceLabel(t, confidence), [t]);
 
@@ -419,6 +420,9 @@ export default function ContributeValidate() {
     typeof t.contributeRescanOffsetsLabel === 'string'
       ? t.contributeRescanOffsetsLabel
       : 'Offsets (px)';
+  const resultPicture = typeof result?.picture === 'string' ? result.picture : '';
+  const hasResultPicture = Boolean(resultPicture);
+  const resultId = result?.id || null;
   const getGroupOffsetLabel = React.useCallback(
     (groupIndex) => {
       if (typeof t.contributeRescanGroupOffsetLabel === 'function') {
@@ -428,6 +432,24 @@ export default function ContributeValidate() {
     },
     [t],
   );
+
+  React.useEffect(() => {
+    setShowPictureModal(false);
+  }, [resultId]);
+
+  const handleOpenPicture = React.useCallback(() => {
+    if (resultPicture) {
+      setShowPictureModal(true);
+    }
+  }, [resultPicture]);
+
+  const handleClosePicture = React.useCallback(() => {
+    setShowPictureModal(false);
+  }, []);
+  const originalPictureAlt =
+    typeof t.contributeOriginalScreenshotAlt === 'string'
+      ? t.contributeOriginalScreenshotAlt
+      : t.contributeResultsTitle;
 
   React.useEffect(() => {
     let active = true;
@@ -1926,6 +1948,15 @@ export default function ContributeValidate() {
 
   return (
     <section className="contribute-validate">
+      {showPictureModal && hasResultPicture ? (
+        <div className="contribute-picture-modal" onClick={handleClosePicture} role="presentation">
+          <img
+            className="contribute-picture-modal-image"
+            src={resultPicture}
+            alt={originalPictureAlt}
+          />
+        </div>
+      ) : null}
       <p className="page-description">{t.contributeValidateDescription}</p>
       <div className="contribute-validate-layout">
         <section className="form contribute-form" aria-live="polite">
@@ -2025,7 +2056,23 @@ export default function ContributeValidate() {
           {result ? (
             <div className={`form contribute-results${showSuccess ? '' : ' contribute-results--hide-success'}`}>
               <div className="contribute-results-top">
-                <h2 className="contribute-section-title">{t.contributeResultsTitle}</h2>
+                <div className="contribute-results-heading">
+                  {hasResultPicture ? (
+                    <button
+                      type="button"
+                      className="contribute-results-picture-button"
+                      onClick={handleOpenPicture}
+                      title={originalPictureAlt}
+                    >
+                      <img
+                        className="contribute-results-picture-thumb"
+                        src={resultPicture}
+                        alt={originalPictureAlt}
+                      />
+                    </button>
+                  ) : null}
+                  <h2 className="contribute-section-title">{t.contributeResultsTitle}</h2>
+                </div>
                 <div className="contribute-results-actions">
                   {selectedScanId ? (
                     <>


### PR DESCRIPTION
## Summary
- show the original scan thumbnail next to the "Detected runs" heading on the contributor validation page
- allow contributors to enlarge the thumbnail in a dismissible modal overlay
- add localized alt text and styling for the new thumbnail and modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daeaed29c0832c9355407388b9ceb1