### PR TITLE
Expose linked characters on player profile pages

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerProfileAlternateResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerProfileAlternateResponse.java
@@ -1,0 +1,16 @@
+package com.opyruso.nwleaderboard.dto;
+
+/**
+ * Lightweight summary of an alternate character linked to a main account.
+ */
+public record PlayerProfileAlternateResponse(Long playerId, String playerName) {
+
+    public PlayerProfileAlternateResponse {
+        if (playerName != null) {
+            playerName = playerName.strip();
+            if (playerName.isEmpty()) {
+                playerName = null;
+            }
+        }
+    }
+}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerProfileResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerProfileResponse.java
@@ -12,7 +12,8 @@ public record PlayerProfileResponse(
         String region,
         Long mainPlayerId,
         String mainPlayerName,
-        List<PlayerDungeonBestResponse> dungeons) {
+        List<PlayerDungeonBestResponse> dungeons,
+        List<PlayerProfileAlternateResponse> alternatePlayers) {
 
     public PlayerProfileResponse {
         if (playerName != null) {
@@ -33,6 +34,8 @@ public record PlayerProfileResponse(
             mainPlayerName = null;
         }
         dungeons = dungeons == null ? List.of() : List.copyOf(dungeons);
+        alternatePlayers =
+                alternatePlayers == null ? List.of() : List.copyOf(alternatePlayers);
     }
 }
 

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2186,6 +2186,36 @@ body[data-theme='light'] .player-profile-region {
   opacity: 0.7;
 }
 
+.player-profile-related {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+body[data-theme='light'] .player-profile-related {
+  color: rgba(30, 41, 59, 0.72);
+}
+
+.player-profile-related-label {
+  font-weight: 600;
+}
+
+.player-profile-related-link {
+  color: inherit;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.player-profile-related-link:hover,
+.player-profile-related-link:focus-visible {
+  text-decoration: none;
+}
+
+.player-profile-related-separator {
+  color: inherit;
+}
+
 .player-main-link-form {
   display: grid;
   gap: 0.75rem;

--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -428,6 +428,8 @@ const de = {
   playerMainLinkHint: 'Gib den Namen des Main-Charakters ein. Leer lassen, um die Verknüpfung zu entfernen.',
   playerMainLinkError:
     'Verknüpfung konnte nicht aktualisiert werden. Stelle sicher, dass beide Spieler in derselben Region sind.',
+  playerAlternateListLabel: 'Nebencharaktere:',
+  playerMainAccountLabel: 'Hauptkonto:',
   playerSearchLoading: 'Spielersuche…',
   playerSearchError: 'Spieler können derzeit nicht gesucht werden.',
   playerSearchNoResults: 'Keine Spieler gefunden.',

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -429,6 +429,8 @@ const en = {
   playerMainLinkHint: 'Enter the main character name to associate. Leave empty to remove the link.',
   playerMainLinkError:
     'Unable to update the main character link. Make sure both players belong to the same region.',
+  playerAlternateListLabel: 'Alternate characters:',
+  playerMainAccountLabel: 'Main account:',
   playerSearchLoading: 'Searching players…',
   playerSearchError: 'Unable to search players right now.',
   playerSearchNoResults: 'No players match this search yet.',

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -431,6 +431,8 @@ const es = {
     'Introduce el nombre del personaje principal para asociarlo. Déjalo vacío para eliminar el vínculo.',
   playerMainLinkError:
     'No se puede actualizar el vínculo del personaje principal. Asegúrate de que ambos jugadores pertenezcan a la misma región.',
+  playerAlternateListLabel: 'Personajes secundarios:',
+  playerMainAccountLabel: 'Cuenta principal:',
   playerSearchLoading: 'Buscando jugadores…',
   playerSearchError: 'No se puede buscar jugadores en este momento.',
   playerSearchNoResults: 'Ningún jugador coincide con la búsqueda todavía.',

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -428,6 +428,8 @@ const esmx = {
   playerMainLinkHint: 'Ingresa el nombre del personaje principal. Deja vacío para quitar el vínculo.',
   playerMainLinkError:
     'No se puede actualizar el vínculo del personaje principal. Verifica que los jugadores sean de la misma región.',
+  playerAlternateListLabel: 'Personajes secundarios:',
+  playerMainAccountLabel: 'Cuenta principal:',
   playerSearchLoading: 'Buscando jugadores…',
   playerSearchError: 'No se pueden buscar jugadores en este momento.',
   playerSearchNoResults: 'Aún no hay jugadores que coincidan.',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -437,6 +437,8 @@ const fr = {
     'Saisissez le nom du personnage principal à associer. Laissez vide pour retirer le lien.',
   playerMainLinkError:
     'Impossible de lier ce personnage. Assurez-vous que les deux joueurs sont dans la même région.',
+  playerAlternateListLabel: 'Personnages secondaires :',
+  playerMainAccountLabel: 'Compte principal :',
   playerSearchLoading: 'Recherche des joueurs…',
   playerSearchError: 'Impossible de rechercher des joueurs pour le moment.',
   playerSearchNoResults: 'Aucun joueur ne correspond pour le moment.',

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -429,6 +429,8 @@ const it = {
     'Inserisci il nome del personaggio principale da associare. Lascia vuoto per rimuovere il collegamento.',
   playerMainLinkError:
     'Impossibile aggiornare il collegamento. Assicurati che i giocatori siano nella stessa regione.',
+  playerAlternateListLabel: 'Personaggi secondari:',
+  playerMainAccountLabel: 'Account principale:',
   playerSearchLoading: 'Ricerca giocatori…',
   playerSearchError: 'Impossibile cercare i giocatori in questo momento.',
   playerSearchNoResults: 'Nessun giocatore corrispondente al momento.',

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -428,6 +428,8 @@ const pl = {
   playerMainLinkHint: 'Podaj nazwę postaci głównej. Pozostaw puste, aby usunąć powiązanie.',
   playerMainLinkError:
     'Nie udało się zaktualizować powiązania. Upewnij się, że gracze są w tym samym regionie.',
+  playerAlternateListLabel: 'Postacie poboczne:',
+  playerMainAccountLabel: 'Konto główne:',
   playerSearchLoading: 'Wyszukiwanie graczy…',
   playerSearchError: 'Nie można teraz wyszukać graczy.',
   playerSearchNoResults: 'Brak dopasowań.',

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -429,6 +429,8 @@ const pt = {
     'Informe o nome do personagem principal para associar. Deixe em branco para remover o vínculo.',
   playerMainLinkError:
     'Não foi possível atualizar o vínculo. Verifique se os jogadores estão na mesma região.',
+  playerAlternateListLabel: 'Personagens secundários:',
+  playerMainAccountLabel: 'Conta principal:',
   playerSearchLoading: 'Buscando jogadores…',
   playerSearchError: 'Não foi possível buscar jogadores agora.',
   playerSearchNoResults: 'Nenhum jogador corresponde à busca ainda.',

--- a/nwleaderboard-ui/js/pages/Player.js
+++ b/nwleaderboard-ui/js/pages/Player.js
@@ -718,6 +718,7 @@ export default function Player({ canContribute = false }) {
   const playerNameInfo = React.useMemo(() => getPlayerNames(profile), [profile]);
   const playerPrimaryName = playerNameInfo.playerName || '';
   const playerMainName = playerNameInfo.mainPlayerName || '';
+  const playerMainId = playerNameInfo.mainPlayerId || null;
   const playerIsAlt = Boolean(playerNameInfo.isAlt);
 
   const playerHeadingName = React.useMemo(() => {
@@ -739,6 +740,75 @@ export default function Player({ canContribute = false }) {
     }
     return '';
   }, [profile, hasPlayerId, normalisedPlayerId]);
+
+  const alternatePlayers = React.useMemo(() => {
+    if (!profile) {
+      return [];
+    }
+    const sourceList = Array.isArray(profile.alternatePlayers)
+      ? profile.alternatePlayers
+      : Array.isArray(profile.alternate_players)
+      ? profile.alternate_players
+      : [];
+    if (sourceList.length === 0) {
+      return [];
+    }
+    const seenIds = new Set();
+    const results = [];
+    sourceList.forEach((entry, index) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const link = formatPlayerLinkProps(entry);
+      let id = link.id;
+      if (!id && entry.playerId !== undefined && entry.playerId !== null) {
+        id = String(entry.playerId);
+      }
+      if (!id && entry.player_id !== undefined && entry.player_id !== null) {
+        id = String(entry.player_id);
+      }
+      if (!id) {
+        return;
+      }
+      const normalisedId = String(id).trim();
+      if (!normalisedId || seenIds.has(normalisedId)) {
+        return;
+      }
+      const name = typeof link.displayName === 'string' ? link.displayName.trim() : '';
+      if (!name) {
+        return;
+      }
+      seenIds.add(normalisedId);
+      results.push({
+        id: normalisedId,
+        name,
+        tooltip: typeof link.tooltip === 'string' && link.tooltip.trim() ? link.tooltip : undefined,
+      });
+    });
+    return results;
+  }, [profile]);
+
+  const mainPlayerLink = React.useMemo(() => {
+    const rawId =
+      profile && profile.mainPlayerId !== undefined && profile.mainPlayerId !== null
+        ? profile.mainPlayerId
+        : profile && profile.main_player_id !== undefined && profile.main_player_id !== null
+        ? profile.main_player_id
+        : playerMainId;
+    const rawName =
+      profile && typeof profile.mainPlayerName === 'string'
+        ? profile.mainPlayerName
+        : profile && typeof profile.main_player_name === 'string'
+        ? profile.main_player_name
+        : playerMainName;
+    const id =
+      rawId === undefined || rawId === null ? '' : String(rawId).trim();
+    const name = typeof rawName === 'string' ? rawName.trim() : '';
+    if (!id || !name) {
+      return null;
+    }
+    return { id, name };
+  }, [playerMainId, playerMainName, profile]);
 
   const handleSearchChange = React.useCallback((event) => {
     setSearchTerm(event.target.value);
@@ -951,6 +1021,40 @@ export default function Player({ canContribute = false }) {
                 ''
               )}
             </h2>
+            {playerIsAlt && mainPlayerLink ? (
+              <p className="player-profile-related player-profile-main-account">
+                <span className="player-profile-related-label">
+                  {t.playerMainAccountLabel || 'Main account:'}
+                </span>{' '}
+                <Link
+                  to={`/player/${encodeURIComponent(mainPlayerLink.id)}`}
+                  className="player-profile-related-link"
+                >
+                  {mainPlayerLink.name}
+                </Link>
+              </p>
+            ) : null}
+            {!playerIsAlt && alternatePlayers.length > 0 ? (
+              <p className="player-profile-related player-profile-alternate-list">
+                <span className="player-profile-related-label">
+                  {t.playerAlternateListLabel || 'Alternate characters:'}
+                </span>{' '}
+                {alternatePlayers.map((alt, index) => (
+                  <React.Fragment key={alt.id || `${alt.name}-${index}`}>
+                    {index > 0 ? (
+                      <span className="player-profile-related-separator">, </span>
+                    ) : null}
+                    <Link
+                      to={`/player/${encodeURIComponent(alt.id)}`}
+                      className="player-profile-related-link"
+                      title={alt.tooltip || undefined}
+                    >
+                      {alt.name}
+                    </Link>
+                  </React.Fragment>
+                ))}
+              </p>
+            ) : null}
             {playerPrimaryName && playerIdentifier ? (
               <p className="player-profile-identifier">
                 {typeof t.playerIdLabel === 'function'


### PR DESCRIPTION
## Summary
- extend the player profile API response with a lightweight alternate character list
- show the main account link for alt profiles and render clickable alternates for mains, including styling updates
- translate the new labels across supported locales

## Testing
- mvn -f nwleaderboard-api/pom.xml test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dae9403114832c9f07809cc64c7a5d