### PR TITLE
Respect season filter when showing player badges

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/repository/RunScoreRepository.java
@@ -217,7 +217,11 @@ public class RunScoreRepository implements PanacheRepository<RunScore> {
      * @return one-based position or {@code null} when it cannot be determined
      */
     public Integer findPositionInDungeon(RunScore run) {
-        if (run == null) {
+        return findPositionInDungeon(run, null);
+    }
+
+    public Integer findPositionInDungeon(RunScore run, Collection<Integer> weeks) {
+        if (run == null || (weeks != null && weeks.isEmpty())) {
             return null;
         }
         Long dungeonId = run.getDungeon() != null ? run.getDungeon().getId() : null;
@@ -229,19 +233,27 @@ public class RunScoreRepository implements PanacheRepository<RunScore> {
         }
 
         Long safeRunId = runId != null ? runId : Long.MAX_VALUE;
-        Long betterCount = getEntityManager()
-                .createQuery(
-                        "SELECT COUNT(other) FROM RunScore other "
-                                + "WHERE other.dungeon.id = :dungeonId "
-                                + "AND (other.score > :score "
-                                + "OR (other.score = :score AND COALESCE(other.week, -1) > COALESCE(:week, -1)) "
-                                + "OR (other.score = :score AND COALESCE(other.week, -1) = COALESCE(:week, -1) AND other.id < :runId))",
-                        Long.class)
+        StringBuilder jpql = new StringBuilder(
+                "SELECT COUNT(other) FROM RunScore other "
+                        + "WHERE other.dungeon.id = :dungeonId ");
+        if (weeks != null && !weeks.isEmpty()) {
+            jpql.append("AND other.week IN :weeks ");
+        }
+        jpql.append(
+                "AND (other.score > :score "
+                        + "OR (other.score = :score AND COALESCE(other.week, -1) > COALESCE(:week, -1)) "
+                        + "OR (other.score = :score AND COALESCE(other.week, -1) = COALESCE(:week, -1) AND other.id < :runId))");
+
+        var query = getEntityManager()
+                .createQuery(jpql.toString(), Long.class)
                 .setParameter("dungeonId", dungeonId)
                 .setParameter("score", score)
                 .setParameter("week", week)
-                .setParameter("runId", safeRunId)
-                .getSingleResult();
+                .setParameter("runId", safeRunId);
+        if (weeks != null && !weeks.isEmpty()) {
+            query.setParameter("weeks", weeks);
+        }
+        Long betterCount = query.getSingleResult();
         if (betterCount == null) {
             return null;
         }


### PR DESCRIPTION
## Summary
- ensure player profile badge positions are calculated against runs from the selected season
- extend run repositories so position lookups can apply the season week filter shared by the profile service

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68db606fa658832c8f26a1b23b147ec9