### PR TITLE
Add shimmering effect to highlighted dungeons

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerDungeonBestResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerDungeonBestResponse.java
@@ -9,6 +9,7 @@ public record PlayerDungeonBestResponse(
         Long dungeonId,
         String fallbackName,
         Map<String, String> names,
+        boolean highlighted,
         Integer bestScore,
         Integer bestScoreWeek,
         Integer bestScorePosition,

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/PlayerProfileService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/PlayerProfileService.java
@@ -278,6 +278,7 @@ public class PlayerProfileService {
                 dungeonId,
                 fallbackName,
                 names,
+                dungeon != null && dungeon.isHighlighted(),
                 scoreValue,
                 scoreWeek,
                 scorePosition,

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2639,6 +2639,9 @@ body[data-theme='light'] .player-chart-card {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  position: relative;
+  overflow: hidden;
+  z-index: 0;
 }
 
 body[data-theme='light'] .player-dungeon-card {
@@ -3077,6 +3080,9 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   border: 1px solid rgba(124, 92, 255, 0.4);
   background: rgba(124, 92, 255, 0.12);
   box-shadow: 0 12px 28px rgba(124, 92, 255, 0.28);
+  position: relative;
+  overflow: hidden;
+  z-index: 0;
 }
 
 .dungeon-selected-icon {
@@ -3125,6 +3131,9 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   cursor: pointer;
   transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
     transform 0.2s ease;
+  position: relative;
+  overflow: hidden;
+  z-index: 0;
 }
 
 .dungeon-grid-button-icon {
@@ -3151,6 +3160,65 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
 .dungeon-grid-button.active .dungeon-grid-button-icon,
 .dungeon-grid-button[aria-pressed='true'] .dungeon-grid-button-icon {
   filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.35));
+}
+
+.highlighted-glow {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(250, 204, 21, 0.65);
+  z-index: 0;
+}
+
+.highlighted-glow::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  border: 1px solid rgba(250, 204, 21, 0.65);
+  box-shadow: 0 0 18px rgba(250, 204, 21, 0.4), 0 0 30px rgba(250, 204, 21, 0.25);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.highlighted-glow::after {
+  content: '';
+  position: absolute;
+  inset: -20%;
+  border-radius: inherit;
+  background: linear-gradient(
+    120deg,
+    rgba(250, 204, 21, 0) 0%,
+    rgba(250, 204, 21, 0.55) 45%,
+    rgba(250, 204, 21, 0) 70%
+  );
+  background-size: 260% 160%;
+  animation: highlighted-glow-shimmer 3s linear infinite;
+  opacity: 0.45;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  z-index: 1;
+}
+
+body[data-theme='light'] .highlighted-glow {
+  border-color: rgba(217, 119, 6, 0.55);
+}
+
+body[data-theme='light'] .highlighted-glow::before {
+  border-color: rgba(217, 119, 6, 0.55);
+  box-shadow: 0 0 14px rgba(217, 119, 6, 0.35), 0 0 26px rgba(217, 119, 6, 0.18);
+}
+
+body[data-theme='light'] .highlighted-glow::after {
+  opacity: 0.35;
+}
+
+@keyframes highlighted-glow-shimmer {
+  0% {
+    background-position: 200% 50%;
+  }
+  100% {
+    background-position: -200% 50%;
+  }
 }
 
 body[data-theme='light'] .dungeon-selected-display {

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2644,10 +2644,35 @@ body[data-theme='light'] .player-chart-card {
   z-index: 0;
 }
 
+.player-dungeon-card.highlighted-glow {
+  background: linear-gradient(180deg, rgba(250, 204, 21, 0.14) 0%, rgba(250, 204, 21, 0.04) 65%),
+    var(--surface-dark);
+  box-shadow: 0 28px 52px rgba(5, 10, 25, 0.58), 0 0 38px rgba(250, 204, 21, 0.28);
+}
+
+.player-dungeon-card.highlighted-glow .player-dungeon-value,
+.player-dungeon-card.highlighted-glow .player-dungeon-week {
+  color: #facc15;
+  text-shadow: 0 0 12px rgba(250, 204, 21, 0.45), 0 0 26px rgba(250, 204, 21, 0.25);
+}
+
 body[data-theme='light'] .player-dungeon-card {
   background: var(--surface-light);
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
   border-color: var(--border-light);
+}
+
+body[data-theme='light'] .player-dungeon-card.highlighted-glow {
+  background: linear-gradient(180deg, rgba(217, 119, 6, 0.16) 0%, rgba(217, 119, 6, 0.05) 60%),
+    rgba(255, 255, 255, 0.88);
+  box-shadow: 0 20px 42px rgba(15, 23, 42, 0.2), 0 0 30px rgba(217, 119, 6, 0.24);
+  border-color: rgba(217, 119, 6, 0.5);
+}
+
+body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-value,
+body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-week {
+  color: #b45309;
+  text-shadow: 0 0 10px rgba(217, 119, 6, 0.35), 0 0 20px rgba(217, 119, 6, 0.2);
 }
 
 .player-dungeon-name {
@@ -2673,57 +2698,6 @@ body[data-theme='light'] .player-dungeon-card {
   position: relative;
   padding-top: 3.25rem;
   border-radius: 16px;
-}
-
-.player-dungeon-stat.highlighted-glow {
-  padding: 3.25rem 1.25rem 1.25rem;
-  margin: 0 -0.5rem;
-  border: 1px solid transparent;
-  background: linear-gradient(180deg, rgba(250, 204, 21, 0.1) 0%, rgba(250, 204, 21, 0) 85%);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45), 0 0 36px rgba(250, 204, 21, 0.22);
-}
-
-.player-dungeon-stat.highlighted-glow::before {
-  border-radius: 18px;
-  background: radial-gradient(
-      160% 120% at 50% 0%,
-      rgba(250, 204, 21, 0.4) 0%,
-      rgba(250, 204, 21, 0) 70%
-    ),
-    rgba(15, 23, 42, 0.65);
-  opacity: 0.6;
-}
-
-.player-dungeon-stat.highlighted-glow::after {
-  border-radius: 18px;
-}
-
-.player-dungeon-stat.highlighted-glow .player-dungeon-value,
-.player-dungeon-stat.highlighted-glow .player-dungeon-week {
-  color: #facc15;
-  text-shadow: 0 0 12px rgba(250, 204, 21, 0.4), 0 0 28px rgba(250, 204, 21, 0.25);
-}
-
-body[data-theme='light'] .player-dungeon-stats--highlighted .player-dungeon-stat.highlighted-glow {
-  background: linear-gradient(180deg, rgba(217, 119, 6, 0.15) 0%, rgba(217, 119, 6, 0.02) 85%),
-    rgba(255, 255, 255, 0.9);
-  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18), 0 0 26px rgba(217, 119, 6, 0.22);
-}
-
-body[data-theme='light'] .player-dungeon-stat.highlighted-glow::before {
-  background: radial-gradient(
-      160% 120% at 50% 0%,
-      rgba(217, 119, 6, 0.38) 0%,
-      rgba(217, 119, 6, 0) 70%
-    ),
-    rgba(255, 255, 255, 0.8);
-  opacity: 0.65;
-}
-
-body[data-theme='light'] .player-dungeon-stat.highlighted-glow .player-dungeon-value,
-body[data-theme='light'] .player-dungeon-stat.highlighted-glow .player-dungeon-week {
-  color: #b45309;
-  text-shadow: 0 0 10px rgba(217, 119, 6, 0.35), 0 0 20px rgba(217, 119, 6, 0.2);
 }
 
 
@@ -3242,7 +3216,7 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
 .highlighted-glow::after {
   content: '';
   position: absolute;
-  inset: -26%;
+  inset: -18%;
   border-radius: inherit;
   background: linear-gradient(
     125deg,
@@ -3254,7 +3228,7 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   filter: blur(0.5px);
   opacity: 0;
   transform: translate3d(-130%, 0, 0) skewX(-12deg);
-  animation: highlighted-glow-shimmer 12s linear infinite;
+  animation: highlighted-glow-shimmer 7.5s linear infinite;
   pointer-events: none;
   mix-blend-mode: screen;
   z-index: 1;

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2644,18 +2644,10 @@ body[data-theme='light'] .player-chart-card {
   z-index: 0;
 }
 
-.player-dungeon-card.highlighted-glow {
-  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.55), 0 0 42px rgba(250, 204, 21, 0.22);
-}
-
 body[data-theme='light'] .player-dungeon-card {
   background: var(--surface-light);
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
   border-color: var(--border-light);
-}
-
-body[data-theme='light'] .player-dungeon-card.highlighted-glow {
-  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12), 0 0 36px rgba(217, 119, 6, 0.24);
 }
 
 .player-dungeon-name {
@@ -2670,52 +2662,70 @@ body[data-theme='light'] .player-dungeon-card.highlighted-glow {
   gap: 1rem;
 }
 
+.player-dungeon-stats--highlighted {
+  position: relative;
+  gap: 1.25rem;
+}
+
 .player-dungeon-stat {
   display: grid;
   gap: 0.35rem;
   position: relative;
   padding-top: 3.25rem;
-}
-
-.player-dungeon-card.highlighted-glow .player-dungeon-stat {
-  z-index: 0;
-}
-
-.player-dungeon-card.highlighted-glow .player-dungeon-stat::before {
-  content: '';
-  position: absolute;
-  inset: 0.25rem 0;
   border-radius: 16px;
-  background: radial-gradient(
-    125% 160% at 50% 0%,
-    rgba(250, 204, 21, 0.38) 0%,
-    rgba(250, 204, 21, 0) 72%
-  );
-  opacity: 0.45;
-  pointer-events: none;
-  z-index: -1;
 }
 
-.player-dungeon-card.highlighted-glow .player-dungeon-value,
-.player-dungeon-card.highlighted-glow .player-dungeon-week {
+.player-dungeon-stat.highlighted-glow {
+  padding: 3.25rem 1.25rem 1.25rem;
+  margin: 0 -0.5rem;
+  border: 1px solid transparent;
+  background: linear-gradient(180deg, rgba(250, 204, 21, 0.1) 0%, rgba(250, 204, 21, 0) 85%);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45), 0 0 36px rgba(250, 204, 21, 0.22);
+}
+
+.player-dungeon-stat.highlighted-glow::before {
+  border-radius: 18px;
+  background: radial-gradient(
+      160% 120% at 50% 0%,
+      rgba(250, 204, 21, 0.4) 0%,
+      rgba(250, 204, 21, 0) 70%
+    ),
+    rgba(15, 23, 42, 0.65);
+  opacity: 0.6;
+}
+
+.player-dungeon-stat.highlighted-glow::after {
+  border-radius: 18px;
+}
+
+.player-dungeon-stat.highlighted-glow .player-dungeon-value,
+.player-dungeon-stat.highlighted-glow .player-dungeon-week {
   color: #facc15;
-  text-shadow: 0 0 12px rgba(250, 204, 21, 0.45), 0 0 24px rgba(250, 204, 21, 0.25);
+  text-shadow: 0 0 12px rgba(250, 204, 21, 0.4), 0 0 28px rgba(250, 204, 21, 0.25);
 }
 
-body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-stat::before {
+body[data-theme='light'] .player-dungeon-stats--highlighted .player-dungeon-stat.highlighted-glow {
+  background: linear-gradient(180deg, rgba(217, 119, 6, 0.15) 0%, rgba(217, 119, 6, 0.02) 85%),
+    rgba(255, 255, 255, 0.9);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18), 0 0 26px rgba(217, 119, 6, 0.22);
+}
+
+body[data-theme='light'] .player-dungeon-stat.highlighted-glow::before {
   background: radial-gradient(
-    125% 160% at 50% 0%,
-    rgba(217, 119, 6, 0.32) 0%,
-    rgba(217, 119, 6, 0) 72%
-  );
-  opacity: 0.5;
+      160% 120% at 50% 0%,
+      rgba(217, 119, 6, 0.38) 0%,
+      rgba(217, 119, 6, 0) 70%
+    ),
+    rgba(255, 255, 255, 0.8);
+  opacity: 0.65;
 }
 
-body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-value,
-body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-week {
+body[data-theme='light'] .player-dungeon-stat.highlighted-glow .player-dungeon-value,
+body[data-theme='light'] .player-dungeon-stat.highlighted-glow .player-dungeon-week {
   color: #b45309;
-  text-shadow: 0 0 10px rgba(217, 119, 6, 0.4), 0 0 18px rgba(217, 119, 6, 0.24);
+  text-shadow: 0 0 10px rgba(217, 119, 6, 0.35), 0 0 20px rgba(217, 119, 6, 0.2);
 }
+
 
 .player-dungeon-stat dt {
   font-size: 0.9rem;
@@ -3243,8 +3253,8 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   );
   filter: blur(0.5px);
   opacity: 0;
-  transform: translate3d(-120%, 0, 0) skewX(-12deg);
-  animation: highlighted-glow-shimmer 7.5s cubic-bezier(0.52, 0.01, 0.16, 1) infinite;
+  transform: translate3d(-130%, 0, 0) skewX(-12deg);
+  animation: highlighted-glow-shimmer 12s linear infinite;
   pointer-events: none;
   mix-blend-mode: screen;
   z-index: 1;
@@ -3274,29 +3284,29 @@ body[data-theme='light'] .highlighted-glow::after {
 @keyframes highlighted-glow-shimmer {
   0% {
     opacity: 0;
-    transform: translate3d(-125%, 0, 0) skewX(-12deg);
+    transform: translate3d(-130%, 0, 0) skewX(-12deg);
   }
-  12% {
+  15% {
+    opacity: 0.2;
+  }
+  35% {
+    opacity: 0.48;
+    transform: translate3d(-40%, 0, 0) skewX(-6deg);
+  }
+  55% {
+    opacity: 0.6;
+    transform: translate3d(20%, 0, 0) skewX(-2deg);
+  }
+  75% {
+    opacity: 0.45;
+    transform: translate3d(75%, 0, 0) skewX(-4deg);
+  }
+  90% {
     opacity: 0.16;
-  }
-  32% {
-    opacity: 0.45;
-    transform: translate3d(-48%, 0, 0) skewX(-8deg);
-  }
-  50% {
-    opacity: 0.55;
-    transform: translate3d(0%, 0, 0) skewX(0deg);
-  }
-  68% {
-    opacity: 0.45;
-    transform: translate3d(42%, 0, 0) skewX(6deg);
-  }
-  88% {
-    opacity: 0.14;
   }
   100% {
     opacity: 0;
-    transform: translate3d(120%, 0, 0) skewX(12deg);
+    transform: translate3d(130%, 0, 0) skewX(-12deg);
   }
 }
 

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -762,7 +762,8 @@ body[data-theme='light'] .theme-slider input[type='range']::-moz-range-thumb {
   margin-top: 1rem;
 }
 
-.form-actions button {
+.form-actions button,
+.form-actions .form-action-link {
   padding: 0.75rem 1.5rem;
   border-radius: 999px;
   border: none;
@@ -774,7 +775,16 @@ body[data-theme='light'] .theme-slider input[type='range']::-moz-range-thumb {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.form-actions button.secondary {
+.form-actions .form-action-link {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid transparent;
+}
+
+.form-actions button.secondary,
+.form-actions .form-action-link.secondary {
   background: transparent;
   color: inherit;
   border: 2px solid currentColor;
@@ -785,7 +795,9 @@ body[data-theme='light'] .theme-slider input[type='range']::-moz-range-thumb {
   cursor: not-allowed;
 }
 
-.form-actions button:hover:not(:disabled) {
+.form-actions button:hover:not(:disabled),
+.form-actions .form-action-link:hover,
+.form-actions .form-action-link:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 14px 28px rgba(124, 92, 255, 0.4);
 }
@@ -3216,19 +3228,20 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
 .highlighted-glow::after {
   content: '';
   position: absolute;
-  inset: -18%;
+  inset: -45%;
   border-radius: inherit;
   background: linear-gradient(
-    125deg,
-    rgba(250, 204, 21, 0) 20%,
-    rgba(250, 204, 21, 0.55) 47%,
-    rgba(250, 204, 21, 0.35) 55%,
-    rgba(250, 204, 21, 0) 82%
+    118deg,
+    rgba(250, 204, 21, 0) 22%,
+    rgba(250, 204, 21, 0.55) 45%,
+    rgba(250, 204, 21, 0.32) 58%,
+    rgba(250, 204, 21, 0) 78%
   );
-  filter: blur(0.5px);
+  background-repeat: no-repeat;
+  filter: blur(0.8px);
   opacity: 0;
-  transform: translate3d(-130%, 0, 0) skewX(-12deg);
-  animation: highlighted-glow-shimmer 7.5s linear infinite;
+  transform: translate3d(-200%, 0, 0) rotate(18deg);
+  animation: highlighted-glow-shimmer 9s ease-in-out infinite;
   pointer-events: none;
   mix-blend-mode: screen;
   z-index: 1;
@@ -3246,41 +3259,46 @@ body[data-theme='light'] .highlighted-glow::before {
 
 body[data-theme='light'] .highlighted-glow::after {
   background: linear-gradient(
-    125deg,
-    rgba(217, 119, 6, 0) 18%,
-    rgba(217, 119, 6, 0.45) 47%,
-    rgba(217, 119, 6, 0.3) 55%,
-    rgba(217, 119, 6, 0) 82%
+    118deg,
+    rgba(217, 119, 6, 0) 20%,
+    rgba(217, 119, 6, 0.45) 44%,
+    rgba(217, 119, 6, 0.28) 58%,
+    rgba(217, 119, 6, 0) 78%
   );
-  filter: blur(0.65px);
+  filter: blur(0.95px);
 }
 
 @keyframes highlighted-glow-shimmer {
   0% {
     opacity: 0;
-    transform: translate3d(-130%, 0, 0) skewX(-12deg);
+    transform: translate3d(-200%, 0, 0) rotate(18deg);
   }
-  15% {
-    opacity: 0.2;
+  8% {
+    opacity: 0;
   }
-  35% {
-    opacity: 0.48;
-    transform: translate3d(-40%, 0, 0) skewX(-6deg);
+  14% {
+    opacity: 0.35;
+    transform: translate3d(-90%, 0, 0) rotate(16deg);
   }
-  55% {
+  20% {
+    opacity: 0.7;
+    transform: translate3d(-10%, 0, 0) rotate(12deg);
+  }
+  26% {
     opacity: 0.6;
-    transform: translate3d(20%, 0, 0) skewX(-2deg);
+    transform: translate3d(70%, 0, 0) rotate(10deg);
   }
-  75% {
-    opacity: 0.45;
-    transform: translate3d(75%, 0, 0) skewX(-4deg);
+  32% {
+    opacity: 0.2;
+    transform: translate3d(150%, 0, 0) rotate(8deg);
   }
-  90% {
-    opacity: 0.16;
+  38% {
+    opacity: 0;
+    transform: translate3d(190%, 0, 0) rotate(6deg);
   }
   100% {
     opacity: 0;
-    transform: translate3d(130%, 0, 0) skewX(-12deg);
+    transform: translate3d(190%, 0, 0) rotate(6deg);
   }
 }
 

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -3244,7 +3244,7 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   filter: blur(0.5px);
   opacity: 0;
   transform: translate3d(-120%, 0, 0) skewX(-12deg);
-  animation: highlighted-glow-shimmer 12s cubic-bezier(0.52, 0.01, 0.16, 1) infinite;
+  animation: highlighted-glow-shimmer 7.5s cubic-bezier(0.52, 0.01, 0.16, 1) infinite;
   pointer-events: none;
   mix-blend-mode: screen;
   z-index: 1;

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2644,10 +2644,18 @@ body[data-theme='light'] .player-chart-card {
   z-index: 0;
 }
 
+.player-dungeon-card.highlighted-glow {
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.55), 0 0 42px rgba(250, 204, 21, 0.22);
+}
+
 body[data-theme='light'] .player-dungeon-card {
   background: var(--surface-light);
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12);
   border-color: var(--border-light);
+}
+
+body[data-theme='light'] .player-dungeon-card.highlighted-glow {
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.12), 0 0 36px rgba(217, 119, 6, 0.24);
 }
 
 .player-dungeon-name {
@@ -3207,6 +3215,7 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   overflow: hidden;
   border-color: rgba(250, 204, 21, 0.65);
   z-index: 0;
+  isolation: isolate;
 }
 
 .highlighted-glow::before {
@@ -3223,20 +3232,23 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
 .highlighted-glow::after {
   content: '';
   position: absolute;
-  inset: -20%;
+  inset: -26%;
   border-radius: inherit;
   background: linear-gradient(
-    120deg,
-    rgba(250, 204, 21, 0) 0%,
-    rgba(250, 204, 21, 0.55) 45%,
-    rgba(250, 204, 21, 0) 70%
+    125deg,
+    rgba(250, 204, 21, 0) 20%,
+    rgba(250, 204, 21, 0.55) 47%,
+    rgba(250, 204, 21, 0.35) 55%,
+    rgba(250, 204, 21, 0) 82%
   );
-  background-size: 260% 160%;
-  animation: highlighted-glow-shimmer 6.5s linear infinite;
-  opacity: 0.45;
+  filter: blur(0.5px);
+  opacity: 0;
+  transform: translate3d(-120%, 0, 0) skewX(-12deg);
+  animation: highlighted-glow-shimmer 12s cubic-bezier(0.52, 0.01, 0.16, 1) infinite;
   pointer-events: none;
   mix-blend-mode: screen;
   z-index: 1;
+  will-change: transform, opacity;
 }
 
 body[data-theme='light'] .highlighted-glow {
@@ -3249,15 +3261,42 @@ body[data-theme='light'] .highlighted-glow::before {
 }
 
 body[data-theme='light'] .highlighted-glow::after {
-  opacity: 0.35;
+  background: linear-gradient(
+    125deg,
+    rgba(217, 119, 6, 0) 18%,
+    rgba(217, 119, 6, 0.45) 47%,
+    rgba(217, 119, 6, 0.3) 55%,
+    rgba(217, 119, 6, 0) 82%
+  );
+  filter: blur(0.65px);
 }
 
 @keyframes highlighted-glow-shimmer {
   0% {
-    background-position: 200% 50%;
+    opacity: 0;
+    transform: translate3d(-125%, 0, 0) skewX(-12deg);
+  }
+  12% {
+    opacity: 0.16;
+  }
+  32% {
+    opacity: 0.45;
+    transform: translate3d(-48%, 0, 0) skewX(-8deg);
+  }
+  50% {
+    opacity: 0.55;
+    transform: translate3d(0%, 0, 0) skewX(0deg);
+  }
+  68% {
+    opacity: 0.45;
+    transform: translate3d(42%, 0, 0) skewX(6deg);
+  }
+  88% {
+    opacity: 0.14;
   }
   100% {
-    background-position: -200% 50%;
+    opacity: 0;
+    transform: translate3d(120%, 0, 0) skewX(12deg);
   }
 }
 

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2669,6 +2669,46 @@ body[data-theme='light'] .player-dungeon-card {
   padding-top: 3.25rem;
 }
 
+.player-dungeon-card.highlighted-glow .player-dungeon-stat {
+  z-index: 0;
+}
+
+.player-dungeon-card.highlighted-glow .player-dungeon-stat::before {
+  content: '';
+  position: absolute;
+  inset: 0.25rem 0;
+  border-radius: 16px;
+  background: radial-gradient(
+    125% 160% at 50% 0%,
+    rgba(250, 204, 21, 0.38) 0%,
+    rgba(250, 204, 21, 0) 72%
+  );
+  opacity: 0.45;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.player-dungeon-card.highlighted-glow .player-dungeon-value,
+.player-dungeon-card.highlighted-glow .player-dungeon-week {
+  color: #facc15;
+  text-shadow: 0 0 12px rgba(250, 204, 21, 0.45), 0 0 24px rgba(250, 204, 21, 0.25);
+}
+
+body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-stat::before {
+  background: radial-gradient(
+    125% 160% at 50% 0%,
+    rgba(217, 119, 6, 0.32) 0%,
+    rgba(217, 119, 6, 0) 72%
+  );
+  opacity: 0.5;
+}
+
+body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-value,
+body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-week {
+  color: #b45309;
+  text-shadow: 0 0 10px rgba(217, 119, 6, 0.4), 0 0 18px rgba(217, 119, 6, 0.24);
+}
+
 .player-dungeon-stat dt {
   font-size: 0.9rem;
   letter-spacing: 0.4px;
@@ -3192,7 +3232,7 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
     rgba(250, 204, 21, 0) 70%
   );
   background-size: 260% 160%;
-  animation: highlighted-glow-shimmer 3s linear infinite;
+  animation: highlighted-glow-shimmer 6.5s linear infinite;
   opacity: 0.45;
   pointer-events: none;
   mix-blend-mode: screen;

--- a/nwleaderboard-ui/js/pages/LeaderboardPage.js
+++ b/nwleaderboard-ui/js/pages/LeaderboardPage.js
@@ -1809,7 +1809,13 @@ export default function LeaderboardPage({
                 <p className="leaderboard-status">{t.dungeonSelectorEmpty}</p>
               ) : (
                 <div className="dungeon-selector-panel">
-                  <div className="dungeon-selected-display">
+                  <div
+                    className={
+                      selectedDungeonDetails?.highlighted
+                        ? 'dungeon-selected-display highlighted-glow'
+                        : 'dungeon-selected-display'
+                    }
+                  >
                     <DungeonIcon dungeonId={selectedDungeonIconId} className="dungeon-selected-icon" />
                     <div className="dungeon-selected-text">
                       <span className="dungeon-selected-label">{t.dungeonSelectorCurrent}</span>
@@ -1825,11 +1831,18 @@ export default function LeaderboardPage({
                           : '';
                       const isActive = selectedDungeon === dungeonId;
                       const dungeonTitle = displayName || dungeonId || t.dungeonSelectorTitle;
+                      const dungeonButtonClass = [
+                        'dungeon-grid-button',
+                        isActive ? 'active' : '',
+                        dungeon?.highlighted ? 'highlighted-glow' : '',
+                      ]
+                        .filter(Boolean)
+                        .join(' ');
                       return (
                         <button
                           key={dungeon.id}
                           type="button"
-                          className={isActive ? 'dungeon-grid-button active' : 'dungeon-grid-button'}
+                          className={dungeonButtonClass}
                           onClick={() => handleSelectDungeon(dungeonId)}
                           aria-pressed={isActive}
                           title={dungeonTitle}

--- a/nwleaderboard-ui/js/pages/Login.js
+++ b/nwleaderboard-ui/js/pages/Login.js
@@ -1,6 +1,8 @@
 import { LangContext } from '../i18n.js';
 import { loginWithPassword } from '../auth.js';
 
+const { Link } = ReactRouterDOM;
+
 const LANGUAGE_ORDER = ['en', 'fr', 'de', 'es', 'esmx', 'it', 'pl', 'pt'];
 
 export default function Login({ onLogin }) {
@@ -96,6 +98,12 @@ export default function Login({ onLogin }) {
           <button type="submit" disabled={status === 'loading'}>
             {status === 'loading' ? '…' : t.loginAction}
           </button>
+          <Link className="form-action-link secondary" to="/register">
+            {t.register}
+          </Link>
+          <Link className="form-action-link secondary" to="/forgot-password">
+            {t.forgotPassword}
+          </Link>
         </div>
       </form>
       <div className="form-footer">

--- a/nwleaderboard-ui/js/pages/Player.js
+++ b/nwleaderboard-ui/js/pages/Player.js
@@ -1,5 +1,5 @@
 import { LangContext } from '../i18n.js';
-import { getDungeonIconPath, getDungeonNameForLang, sortDungeons } from '../dungeons.js';
+import { getDungeonIconPath, getDungeonNameForLang, parseBoolean, sortDungeons } from '../dungeons.js';
 import ChartCanvas from '../components/ChartCanvas.js';
 import DungeonIcon from '../components/DungeonIcon.js';
 import MutationIconList from '../components/MutationIconList.js';
@@ -618,6 +618,13 @@ export default function Player({ canContribute = false }) {
       id: entry?.dungeonId !== undefined && entry?.dungeonId !== null ? String(entry.dungeonId) : `dungeon-${index}`,
       names: entry?.names || {},
       fallbackName: entry?.fallbackName || '',
+      highlighted: parseBoolean(
+        entry?.highlighted ??
+          entry?.is_highlighted ??
+          entry?.isHighlighted ??
+          entry?.featured ??
+          entry?.isFeatured,
+      ),
       bestScore: entry?.bestScore ?? null,
       bestScoreWeek: entry?.bestScoreWeek ?? null,
       bestScorePosition: entry?.bestScorePosition ?? entry?.best_score_position ?? null,
@@ -1524,7 +1531,12 @@ export default function Player({ canContribute = false }) {
                 const scoreWeekLabel = renderWeek(dungeon.bestScoreWeek);
                 const timeWeekLabel = renderWeek(dungeon.bestTimeWeek);
                 return (
-                  <li key={dungeon.id} className="player-dungeon-card">
+                  <li
+                    key={dungeon.id}
+                    className={
+                      dungeon.highlighted ? 'player-dungeon-card highlighted-glow' : 'player-dungeon-card'
+                    }
+                  >
                     <h2 className="player-dungeon-name title-with-icon">
                       <DungeonIcon dungeonId={dungeon.id} />
                       <span>{name}</span>

--- a/nwleaderboard-ui/js/pages/Player.js
+++ b/nwleaderboard-ui/js/pages/Player.js
@@ -1531,18 +1531,25 @@ export default function Player({ canContribute = false }) {
                 const scoreWeekLabel = renderWeek(dungeon.bestScoreWeek);
                 const timeWeekLabel = renderWeek(dungeon.bestTimeWeek);
                 return (
-                  <li
-                    key={dungeon.id}
-                    className={
-                      dungeon.highlighted ? 'player-dungeon-card highlighted-glow' : 'player-dungeon-card'
-                    }
-                  >
+                  <li key={dungeon.id} className="player-dungeon-card">
                     <h2 className="player-dungeon-name title-with-icon">
                       <DungeonIcon dungeonId={dungeon.id} />
                       <span>{name}</span>
                     </h2>
-                    <dl className="player-dungeon-stats">
-                      <div className="player-dungeon-stat">
+                    <dl
+                      className={
+                        dungeon.highlighted
+                          ? 'player-dungeon-stats player-dungeon-stats--highlighted'
+                          : 'player-dungeon-stats'
+                      }
+                    >
+                      <div
+                        className={
+                          dungeon.highlighted
+                            ? 'player-dungeon-stat highlighted-glow'
+                            : 'player-dungeon-stat'
+                        }
+                      >
                         {renderRankIndicator(dungeon.bestScorePosition, t.playerBestScore)}
                         <dt>{t.playerBestScore}</dt>
                         <dd>
@@ -1562,7 +1569,13 @@ export default function Player({ canContribute = false }) {
                           )}
                         </dd>
                       </div>
-                      <div className="player-dungeon-stat">
+                      <div
+                        className={
+                          dungeon.highlighted
+                            ? 'player-dungeon-stat highlighted-glow'
+                            : 'player-dungeon-stat'
+                        }
+                      >
                         {renderRankIndicator(dungeon.bestTimePosition, t.playerBestTime)}
                         <dt>{t.playerBestTime}</dt>
                         <dd>

--- a/nwleaderboard-ui/js/pages/Player.js
+++ b/nwleaderboard-ui/js/pages/Player.js
@@ -1531,7 +1531,14 @@ export default function Player({ canContribute = false }) {
                 const scoreWeekLabel = renderWeek(dungeon.bestScoreWeek);
                 const timeWeekLabel = renderWeek(dungeon.bestTimeWeek);
                 return (
-                  <li key={dungeon.id} className="player-dungeon-card">
+                  <li
+                    key={dungeon.id}
+                    className={
+                      dungeon.highlighted
+                        ? 'player-dungeon-card highlighted-glow'
+                        : 'player-dungeon-card'
+                    }
+                  >
                     <h2 className="player-dungeon-name title-with-icon">
                       <DungeonIcon dungeonId={dungeon.id} />
                       <span>{name}</span>
@@ -1543,13 +1550,7 @@ export default function Player({ canContribute = false }) {
                           : 'player-dungeon-stats'
                       }
                     >
-                      <div
-                        className={
-                          dungeon.highlighted
-                            ? 'player-dungeon-stat highlighted-glow'
-                            : 'player-dungeon-stat'
-                        }
-                      >
+                      <div className="player-dungeon-stat">
                         {renderRankIndicator(dungeon.bestScorePosition, t.playerBestScore)}
                         <dt>{t.playerBestScore}</dt>
                         <dd>
@@ -1569,13 +1570,7 @@ export default function Player({ canContribute = false }) {
                           )}
                         </dd>
                       </div>
-                      <div
-                        className={
-                          dungeon.highlighted
-                            ? 'player-dungeon-stat highlighted-glow'
-                            : 'player-dungeon-stat'
-                        }
-                      >
+                      <div className="player-dungeon-stat">
                         {renderRankIndicator(dungeon.bestTimePosition, t.playerBestTime)}
                         <dt>{t.playerBestTime}</dt>
                         <dd>


### PR DESCRIPTION
## Summary
- add a reusable shimmering glow style for highlighted dungeons
- apply the glow to highlighted dungeon selectors on the score and time leaderboards
- surface the highlighted flag on player dungeon cards and display the glow there too

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd53f7d0e0832cad6b9016aeec252b