### PR TITLE
Remove redundant auth links from navigation

### DIFF
--- a/nwleaderboard-ui/js/BottomNav.js
+++ b/nwleaderboard-ui/js/BottomNav.js
@@ -34,8 +34,6 @@ export default function BottomNav({ authenticated, canContribute = false, onLogo
     <>
       <NavButton to="/preferences">{t.preferences}</NavButton>
       <NavButton to="/login">{t.login}</NavButton>
-      <NavButton to="/register">{t.register}</NavButton>
-      <NavButton to="/forgot-password">{t.forgotPassword}</NavButton>
     </>
   );
 

--- a/nwleaderboard-ui/js/Header.js
+++ b/nwleaderboard-ui/js/Header.js
@@ -355,35 +355,15 @@ export default function Header({ authenticated, canContribute = false, onLogout 
                   </SiteNavButton>
                 </li>
               ) : (
-                <>
-                  <li className="site-nav__item">
-                    <SiteNavLink
-                      to="/register"
-                      isActiveOverride={location.pathname.startsWith('/register')}
-                      onClick={closeMenus}
-                    >
-                      {t.register}
-                    </SiteNavLink>
-                  </li>
-                  <li className="site-nav__item">
-                    <SiteNavLink
-                      to="/forgot-password"
-                      isActiveOverride={location.pathname.startsWith('/forgot-password')}
-                      onClick={closeMenus}
-                    >
-                      {t.forgotPassword}
-                    </SiteNavLink>
-                  </li>
-                  <li className="site-nav__item">
-                    <SiteNavLink
-                      to="/login"
-                      isActiveOverride={location.pathname.startsWith('/login')}
-                      onClick={closeMenus}
-                    >
-                      {t.login}
-                    </SiteNavLink>
-                  </li>
-                </>
+                <li className="site-nav__item">
+                  <SiteNavLink
+                    to="/login"
+                    isActiveOverride={location.pathname.startsWith('/login')}
+                    onClick={closeMenus}
+                  >
+                    {t.login}
+                  </SiteNavLink>
+                </li>
               )}
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- remove the register and forgot password links from the header navigation for signed-out users
- align the bottom navigation to only show login and preferences when not authenticated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd969bfc68832c93435bc3af7be6fa