### PR TITLE
Smooth highlighted dungeon glow animation

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -3267,8 +3267,8 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   background-repeat: no-repeat;
   filter: blur(0.8px);
   opacity: 0;
-  transform: translate3d(-200%, 0, 0) rotate(18deg);
-  animation: highlighted-glow-shimmer 9s ease-in-out infinite;
+  transform: translate3d(-220%, 0, 0) rotate(18deg);
+  animation: highlighted-glow-shimmer 8s linear infinite;
   pointer-events: none;
   mix-blend-mode: screen;
   z-index: 1;
@@ -3293,39 +3293,41 @@ body[data-theme='light'] .highlighted-glow::after {
     rgba(217, 119, 6, 0) 78%
   );
   filter: blur(0.95px);
+  transform: translate3d(-220%, 0, 0) rotate(18deg);
 }
 
 @keyframes highlighted-glow-shimmer {
   0% {
     opacity: 0;
-    transform: translate3d(-200%, 0, 0) rotate(18deg);
+    transform: translate3d(-220%, 0, 0) rotate(18deg);
   }
-  8% {
-    opacity: 0;
-  }
-  14% {
-    opacity: 0.35;
-    transform: translate3d(-90%, 0, 0) rotate(16deg);
+  10% {
+    opacity: 0.15;
+    transform: translate3d(-160%, 0, 0) rotate(16deg);
   }
   20% {
+    opacity: 0.45;
+    transform: translate3d(-60%, 0, 0) rotate(14deg);
+  }
+  30% {
     opacity: 0.7;
-    transform: translate3d(-10%, 0, 0) rotate(12deg);
+    transform: translate3d(40%, 0, 0) rotate(12deg);
   }
-  26% {
-    opacity: 0.6;
-    transform: translate3d(70%, 0, 0) rotate(10deg);
+  40% {
+    opacity: 0.55;
+    transform: translate3d(140%, 0, 0) rotate(10deg);
   }
-  32% {
-    opacity: 0.2;
-    transform: translate3d(150%, 0, 0) rotate(8deg);
+  50% {
+    opacity: 0.25;
+    transform: translate3d(220%, 0, 0) rotate(8deg);
   }
-  38% {
+  60% {
     opacity: 0;
-    transform: translate3d(190%, 0, 0) rotate(6deg);
+    transform: translate3d(300%, 0, 0) rotate(6deg);
   }
   100% {
     opacity: 0;
-    transform: translate3d(190%, 0, 0) rotate(6deg);
+    transform: translate3d(360%, 0, 0) rotate(6deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust highlighted dungeon glow animation timing to remove the mid-cycle pause
- ensure the shimmer travels smoothly across both light and dark themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd97104ed4832c8ede4e90966d92fb