### PR TITLE
Hide site title when scrolling

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -125,6 +125,14 @@ body[data-theme='light'] .site-header {
   gap: clamp(0.75rem, 2vw, 1.1rem);
 }
 
+.site-header--compact .site-header__inner {
+  padding: clamp(0.5rem, 2vw, 0.9rem) clamp(1rem, 4vw, 1.75rem);
+}
+
+.site-header--compact .site-header__brand {
+  display: none;
+}
+
 .site-header__brand {
   display: flex;
   align-items: center;

--- a/nwleaderboard-ui/js/Header.js
+++ b/nwleaderboard-ui/js/Header.js
@@ -38,6 +38,7 @@ export default function Header({ authenticated, canContribute = false, onLogout 
   const location = useLocation();
   const headerRef = React.useRef(null);
   const [openMenu, setOpenMenu] = React.useState(null);
+  const [isScrolled, setIsScrolled] = React.useState(false);
   const isAuthenticated = Boolean(authenticated);
   const showContribute = isAuthenticated && Boolean(canContribute);
   const contributeActive = location.pathname.startsWith('/contribute');
@@ -74,21 +75,37 @@ export default function Header({ authenticated, canContribute = false, onLogout 
     };
   }, [closeMenus]);
 
-  React.useLayoutEffect(() => {
-    function updateHeaderHeight() {
-      if (headerRef.current) {
-        document.documentElement.style.setProperty(
-          '--site-header-height',
-          `${headerRef.current.offsetHeight}px`,
-        );
-      }
+  const updateHeaderHeight = React.useCallback(() => {
+    if (headerRef.current) {
+      document.documentElement.style.setProperty(
+        '--site-header-height',
+        `${headerRef.current.offsetHeight}px`,
+      );
     }
+  }, []);
 
+  React.useLayoutEffect(() => {
     updateHeaderHeight();
+  }, [updateHeaderHeight, isScrolled]);
+
+  React.useLayoutEffect(() => {
     window.addEventListener('resize', updateHeaderHeight);
 
     return () => {
       window.removeEventListener('resize', updateHeaderHeight);
+    };
+  }, [updateHeaderHeight]);
+
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 0);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
     };
   }, []);
 
@@ -129,7 +146,11 @@ export default function Header({ authenticated, canContribute = false, onLogout 
   };
 
   return (
-    <header ref={headerRef} className="site-header" onKeyDown={handleMenuKeyDown}>
+    <header
+      ref={headerRef}
+      className={classNames('site-header', isScrolled ? 'site-header--compact' : '')}
+      onKeyDown={handleMenuKeyDown}
+    >
       <div className="site-header__inner">
         <div className="site-header__brand">
           <img


### PR DESCRIPTION
## Summary
- add scroll detection in the header to toggle a compact state
- hide the site title and shrink header padding when compact to keep only the navigation visible

## Testing
- `npm --prefix nwleaderboard-ui test`


------
https://chatgpt.com/codex/tasks/task_e_68dd97adca2c832c8ee0123e130a2bdb