### PR TITLE
Change highlighted dungeon styling to red

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2684,15 +2684,15 @@ body[data-theme='light'] .player-chart-card {
 }
 
 .player-dungeon-card.highlighted-glow {
-  background: linear-gradient(180deg, rgba(250, 204, 21, 0.14) 0%, rgba(250, 204, 21, 0.04) 65%),
+  background: linear-gradient(180deg, rgba(248, 113, 113, 0.18) 0%, rgba(248, 113, 113, 0.06) 65%),
     var(--surface-dark);
-  box-shadow: 0 28px 52px rgba(5, 10, 25, 0.58), 0 0 38px rgba(250, 204, 21, 0.28);
+  box-shadow: 0 28px 52px rgba(5, 10, 25, 0.58), 0 0 38px rgba(248, 113, 113, 0.28);
 }
 
 .player-dungeon-card.highlighted-glow .player-dungeon-value,
 .player-dungeon-card.highlighted-glow .player-dungeon-week {
-  color: #facc15;
-  text-shadow: 0 0 12px rgba(250, 204, 21, 0.45), 0 0 26px rgba(250, 204, 21, 0.25);
+  color: #f87171;
+  text-shadow: 0 0 12px rgba(248, 113, 113, 0.45), 0 0 26px rgba(248, 113, 113, 0.25);
 }
 
 body[data-theme='light'] .player-dungeon-card {
@@ -2702,16 +2702,16 @@ body[data-theme='light'] .player-dungeon-card {
 }
 
 body[data-theme='light'] .player-dungeon-card.highlighted-glow {
-  background: linear-gradient(180deg, rgba(217, 119, 6, 0.16) 0%, rgba(217, 119, 6, 0.05) 60%),
+  background: linear-gradient(180deg, rgba(220, 38, 38, 0.16) 0%, rgba(220, 38, 38, 0.05) 60%),
     rgba(255, 255, 255, 0.88);
-  box-shadow: 0 20px 42px rgba(15, 23, 42, 0.2), 0 0 30px rgba(217, 119, 6, 0.24);
-  border-color: rgba(217, 119, 6, 0.5);
+  box-shadow: 0 20px 42px rgba(15, 23, 42, 0.2), 0 0 30px rgba(220, 38, 38, 0.24);
+  border-color: rgba(220, 38, 38, 0.5);
 }
 
 body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-value,
 body[data-theme='light'] .player-dungeon-card.highlighted-glow .player-dungeon-week {
-  color: #b45309;
-  text-shadow: 0 0 10px rgba(217, 119, 6, 0.35), 0 0 20px rgba(217, 119, 6, 0.2);
+  color: #b91c1c;
+  text-shadow: 0 0 10px rgba(220, 38, 38, 0.35), 0 0 20px rgba(220, 38, 38, 0.2);
 }
 
 .player-dungeon-name {
@@ -3236,7 +3236,7 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
 .highlighted-glow {
   position: relative;
   overflow: hidden;
-  border-color: rgba(250, 204, 21, 0.65);
+  border-color: rgba(248, 113, 113, 0.65);
   z-index: 0;
   isolation: isolate;
 }
@@ -3246,8 +3246,8 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   position: absolute;
   inset: -1px;
   border-radius: inherit;
-  border: 1px solid rgba(250, 204, 21, 0.65);
-  box-shadow: 0 0 18px rgba(250, 204, 21, 0.4), 0 0 30px rgba(250, 204, 21, 0.25);
+  border: 1px solid rgba(248, 113, 113, 0.65);
+  box-shadow: 0 0 18px rgba(248, 113, 113, 0.4), 0 0 30px rgba(248, 113, 113, 0.25);
   pointer-events: none;
   z-index: 0;
 }
@@ -3259,10 +3259,10 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
   border-radius: inherit;
   background: linear-gradient(
     118deg,
-    rgba(250, 204, 21, 0) 22%,
-    rgba(250, 204, 21, 0.55) 45%,
-    rgba(250, 204, 21, 0.32) 58%,
-    rgba(250, 204, 21, 0) 78%
+    rgba(248, 113, 113, 0) 22%,
+    rgba(248, 113, 113, 0.55) 45%,
+    rgba(248, 113, 113, 0.32) 58%,
+    rgba(248, 113, 113, 0) 78%
   );
   background-repeat: no-repeat;
   filter: blur(0.8px);
@@ -3276,21 +3276,21 @@ body[data-theme='light'] .region-filter-button[aria-pressed='true'] {
 }
 
 body[data-theme='light'] .highlighted-glow {
-  border-color: rgba(217, 119, 6, 0.55);
+  border-color: rgba(220, 38, 38, 0.55);
 }
 
 body[data-theme='light'] .highlighted-glow::before {
-  border-color: rgba(217, 119, 6, 0.55);
-  box-shadow: 0 0 14px rgba(217, 119, 6, 0.35), 0 0 26px rgba(217, 119, 6, 0.18);
+  border-color: rgba(220, 38, 38, 0.55);
+  box-shadow: 0 0 14px rgba(220, 38, 38, 0.35), 0 0 26px rgba(220, 38, 38, 0.18);
 }
 
 body[data-theme='light'] .highlighted-glow::after {
   background: linear-gradient(
     118deg,
-    rgba(217, 119, 6, 0) 20%,
-    rgba(217, 119, 6, 0.45) 44%,
-    rgba(217, 119, 6, 0.28) 58%,
-    rgba(217, 119, 6, 0) 78%
+    rgba(220, 38, 38, 0) 20%,
+    rgba(220, 38, 38, 0.45) 44%,
+    rgba(220, 38, 38, 0.28) 58%,
+    rgba(220, 38, 38, 0) 78%
   );
   filter: blur(0.95px);
   transform: translate3d(-220%, 0, 0) rotate(18deg);


### PR DESCRIPTION
## Summary
- update highlighted dungeon glow styling to use red tones in dark and light themes
- adjust gradient, shadow, and text colors to match the new red highlight treatment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd9872e8f4832cb6d7277c4e46a5ef