### PR TITLE
Remove Cytoscape relationship graph styling

### DIFF
--- a/nwleaderboard-ui/js/pages/Relationship.js
+++ b/nwleaderboard-ui/js/pages/Relationship.js
@@ -1,5 +1,4 @@
 import { LangContext } from '../i18n.js';
-import { ThemeContext } from '../theme.js';
 
 const { Link, useParams } = ReactRouterDOM;
 
@@ -157,6 +156,41 @@ function mergeGraphData(previous, ownerId, payload, t) {
     }
   }
 
+  function registerAlternateEdge(mainPayload, alternatePayload) {
+    if (!mainPayload || !alternatePayload) {
+      return;
+    }
+    const mainId = mainPayload.playerId;
+    const altId = alternatePayload.playerId;
+    if (
+      mainId === null ||
+      mainId === undefined ||
+      altId === null ||
+      altId === undefined ||
+      mainId === altId
+    ) {
+      return;
+    }
+    const mainKey = String(mainId);
+    const altKey = String(altId);
+    const [first, second] = mainKey <= altKey ? [mainKey, altKey] : [altKey, mainKey];
+    const key = `${first}__${second}`;
+    const existing = edges.get(key);
+    const source = existing?.source || mainKey;
+    const target = existing?.target || (source === mainKey ? altKey : mainKey);
+    const runCount = existing?.runCount ?? null;
+    edges.set(key, {
+      id: key,
+      source,
+      target,
+      runCount,
+      alternate: true,
+    });
+    if (ownerKey) {
+      addOwner(edgeOwners, key, ownerKey);
+    }
+  }
+
   if (payload && typeof payload === 'object') {
     registerNode(payload.origin);
     if (Array.isArray(payload.alternates)) {
@@ -167,6 +201,58 @@ function mergeGraphData(previous, ownerId, payload, t) {
     }
     if (Array.isArray(payload.edges)) {
       payload.edges.forEach(registerEdge);
+    }
+
+    let primaryNode = null;
+    const alternates = Array.isArray(payload.alternates) ? payload.alternates : [];
+    if (
+      payload.origin &&
+      payload.origin.playerId !== null &&
+      payload.origin.playerId !== undefined &&
+      payload.origin.origin &&
+      !payload.origin.alternate
+    ) {
+      primaryNode = payload.origin;
+    }
+    if (!primaryNode) {
+      primaryNode = alternates.find(
+        (node) =>
+          node &&
+          node.playerId !== null &&
+          node.playerId !== undefined &&
+          node.alternate === false,
+      );
+    }
+    if (!primaryNode && payload.origin && payload.origin.playerId !== null && payload.origin.playerId !== undefined) {
+      primaryNode = payload.origin;
+    }
+    if (primaryNode) {
+      const primaryId = String(primaryNode.playerId);
+      const uniqueAlternates = new Map();
+      if (
+        payload.origin &&
+        payload.origin.playerId !== null &&
+        payload.origin.playerId !== undefined &&
+        String(payload.origin.playerId) !== primaryId &&
+        payload.origin.alternate
+      ) {
+        uniqueAlternates.set(String(payload.origin.playerId), payload.origin);
+      }
+      alternates.forEach((node) => {
+        if (!node || node.playerId === null || node.playerId === undefined) {
+          return;
+        }
+        const id = String(node.playerId);
+        if (id === primaryId) {
+          return;
+        }
+        if (node.alternate) {
+          uniqueAlternates.set(id, node);
+        }
+      });
+      uniqueAlternates.forEach((node) => {
+        registerAlternateEdge(primaryNode, node);
+      });
     }
   }
 
@@ -212,100 +298,8 @@ function collapseGraphData(previous, ownerId) {
   return { nodes, edges, nodeOwners, edgeOwners, expanded };
 }
 
-function applyGraphTheme(cy, theme) {
-  if (!cy) {
-    return;
-  }
-  const isLight = theme === 'light';
-  const nodeText = isLight ? '#0f172a' : '#f8fafc';
-  const labelBackground = isLight ? 'rgba(226, 232, 240, 0.85)' : 'rgba(15, 23, 42, 0.75)';
-  const relatedBg = isLight ? '#0ea5e9' : '#0284c7';
-  const relatedBorder = isLight ? '#0284c7' : '#38bdf8';
-  const originBg = isLight ? '#6d28d9' : '#7c3aed';
-  const originBorder = isLight ? '#a855f7' : '#c084fc';
-  const altBg = isLight ? '#fb923c' : '#f97316';
-  const altBorder = isLight ? '#f97316' : '#fb923c';
-  const edgeColor = isLight ? '#0f172a' : '#f8fafc';
-  const edgeLine = isLight ? '#64748b' : '#94a3b8';
-  cy.style()
-    .fromJson([
-      {
-        selector: 'node',
-        style: {
-          'background-color': relatedBg,
-          'border-color': relatedBorder,
-          'border-width': 2,
-          'color': nodeText,
-          'width': 'data(size)',
-          'height': 'data(size)',
-          'label': 'data(label)',
-          'font-size': '12px',
-          'text-wrap': 'wrap',
-          'text-max-width': '108px',
-          'text-valign': 'center',
-          'text-halign': 'center',
-          'text-background-color': labelBackground,
-          'text-background-opacity': 1,
-          'text-background-padding': 2,
-        },
-      },
-      {
-        selector: 'node[type = "origin"]',
-        style: {
-          'background-color': originBg,
-          'border-color': originBorder,
-          'font-size': '13px',
-          'font-weight': '600',
-        },
-      },
-      {
-        selector: 'node[type = "alternate"]',
-        style: {
-          'background-color': altBg,
-          'border-color': altBorder,
-        },
-      },
-      {
-        selector: 'edge',
-        style: {
-          'line-color': edgeLine,
-          'width': 'data(width)',
-          'curve-style': 'bezier',
-          'target-arrow-shape': 'none',
-          'control-point-step-size': 60,
-          'label': 'data(label)',
-          'font-size': '11px',
-          'color': edgeColor,
-          'text-background-color': labelBackground,
-          'text-background-opacity': 1,
-          'text-background-padding': 2,
-          'opacity': 0.9,
-        },
-      },
-      {
-        selector: 'edge[alternateLink = 1]',
-        style: {
-          'line-style': 'dashed',
-          'line-color': altBg,
-          'width': 3,
-          'label': '',
-          'opacity': 0.7,
-        },
-      },
-      {
-        selector: 'node:selected',
-        style: {
-          'border-width': 4,
-          'border-color': isLight ? '#2563eb' : '#38bdf8',
-        },
-      },
-    ])
-    .update();
-}
-
 export default function Relationship() {
   const { t } = React.useContext(LangContext);
-  const { theme } = React.useContext(ThemeContext);
   const params = useParams();
   const routePlayerId = params?.playerId;
   const [graphData, setGraphData] = React.useState(() => createEmptyGraphState());
@@ -374,7 +368,6 @@ export default function Relationship() {
     });
     setCyUnavailable(false);
     cyRef.current = cy;
-    applyGraphTheme(cy, theme);
     const handleResize = () => {
       cy.resize();
     };
@@ -385,14 +378,6 @@ export default function Relationship() {
       cyRef.current = null;
     };
   }, []);
-
-  React.useEffect(() => {
-    const cy = cyRef.current;
-    if (!cy) {
-      return;
-    }
-    applyGraphTheme(cy, theme);
-  }, [theme]);
 
   function updateLoadingNodes(updater) {
     setLoadingNodes((prev) => {
@@ -575,30 +560,83 @@ export default function Relationship() {
         randomize: false,
         nodeDimensionsIncludeLabels: true,
         packComponents: true,
-        nodeRepulsion: 130000,
-        nodeSeparation: 150,
+        nodeRepulsion: 140000,
+        nodeSeparation: 180,
         idealEdgeLength: 380,
         edgeElasticity: 0.07,
-        gravity: 0.2,
-        gravityRange: 3.4,
-        gravityCompound: 0.7,
-        gravityRangeCompound: 3,
-        tilingPaddingHorizontal: 112,
-        tilingPaddingVertical: 112,
-        numIter: 2500,
+        gravity: 0.18,
+        gravityRange: 3.5,
+        gravityCompound: 0.65,
+        gravityRangeCompound: 3.1,
+        tilingPaddingHorizontal: 128,
+        tilingPaddingVertical: 128,
+        uniformNodeDimensions: false,
+        numIter: 2800,
       });
     } else {
       Object.assign(layoutOptions, {
-        nodeRepulsion: 160000,
+        nodeDimensionsIncludeLabels: true,
+        nodeRepulsion: 180000,
         idealEdgeLength: 360,
-        edgeElasticity: 0.08,
-        gravity: 0.22,
-        componentSpacing: 380,
-        nodeOverlap: 4,
+        edgeElasticity: 0.07,
+        gravity: 0.2,
+        componentSpacing: 400,
+        nodeOverlap: 12,
       });
     }
-    const layout = cy.layout(layoutOptions);
-    layout.run();
+
+    const runLayout = (options, isFallback = false) => {
+      const layoutInstance = cy.layout(options);
+      if (!isFallback) {
+        layoutInstance.one('layoutstop', () => {
+          const nodes = cy.nodes();
+          if (nodes.length <= 1) {
+            return;
+          }
+          let minX = Infinity;
+          let minY = Infinity;
+          let maxX = -Infinity;
+          let maxY = -Infinity;
+          nodes.forEach((node) => {
+            const position = node.position();
+            if (!position) {
+              return;
+            }
+            if (position.x < minX) {
+              minX = position.x;
+            }
+            if (position.x > maxX) {
+              maxX = position.x;
+            }
+            if (position.y < minY) {
+              minY = position.y;
+            }
+            if (position.y > maxY) {
+              maxY = position.y;
+            }
+          });
+          const spreadX = maxX - minX;
+          const spreadY = maxY - minY;
+          if (spreadX < 120 && spreadY < 120) {
+            runLayout(
+              {
+                name: 'breadthfirst',
+                animate: false,
+                fit: true,
+                padding: 260,
+                circle: false,
+                spacingFactor: 1.4,
+                avoidOverlap: true,
+              },
+              true,
+            );
+          }
+        });
+      }
+      layoutInstance.run();
+    };
+
+    runLayout(layoutOptions);
     cy.resize();
   }, [graphData, t]);
 


### PR DESCRIPTION
## Summary
- remove the Cytoscape theme application so the relationship graph uses the default layout styling

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68de50c4be54832cbbcd0ce1ea6c8312