### PR TITLE
Add relationship graph layout selection controls

### DIFF
--- a/nwleaderboard-ui/build.js
+++ b/nwleaderboard-ui/build.js
@@ -49,6 +49,11 @@ cpSync('node_modules/chart.js/dist/chart.umd.js', 'dist/vendor/chart.umd.js');
 cpSync('node_modules/cytoscape/dist/cytoscape.umd.js', 'dist/vendor/cytoscape.umd.js');
 cpSync('node_modules/layout-base/layout-base.js', 'dist/vendor/layout-base.js');
 cpSync('node_modules/cose-base/cose-base.js', 'dist/vendor/cose-base.js');
+cpSync('node_modules/webcola/WebCola/cola.min.js', 'dist/vendor/cola.min.js');
+cpSync('node_modules/cytoscape-cola/cytoscape-cola.js', 'dist/vendor/cytoscape-cola.js');
+cpSync('node_modules/cytoscape-euler/cytoscape-euler.js', 'dist/vendor/cytoscape-euler.js');
+cpSync('node_modules/weaverjs/dist/weaver.min.js', 'dist/vendor/weaver.min.js');
+cpSync('node_modules/cytoscape-spread/cytoscape-spread.js', 'dist/vendor/cytoscape-spread.js');
 cpSync('node_modules/cytoscape-fcose/cytoscape-fcose.js', 'dist/vendor/cytoscape-fcose.js');
 
 let version = '';

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -4852,6 +4852,53 @@ body[data-theme='light'] .relationship-instructions {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.relationship-layout-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+}
+
+.relationship-layout-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+body[data-theme='light'] .relationship-layout-label {
+  color: rgba(30, 41, 59, 0.68);
+}
+
+.relationship-layout-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.relationship-layout-button {
+  font-size: 0.82rem;
+  padding: 0.35rem 0.85rem;
+}
+
+.relationship-layout-button.is-active {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #bfdbfe;
+}
+
+body[data-theme='light'] .relationship-layout-button.is-active {
+  background: rgba(59, 130, 246, 0.16);
+  border-color: rgba(37, 99, 235, 0.5);
+  color: #1e3a8a;
+}
+
+.relationship-layout-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .relationship-status {

--- a/nwleaderboard-ui/package-lock.json
+++ b/nwleaderboard-ui/package-lock.json
@@ -11,7 +11,10 @@
         "@babel/standalone": "^7.28.1",
         "chart.js": "^4.5.0",
         "cytoscape": "^3.27.0",
+        "cytoscape-cola": "^2.5.1",
+        "cytoscape-euler": "^1.2.3",
         "cytoscape-fcose": "^2.2.0",
+        "cytoscape-spread": "^3.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.0"
@@ -1632,6 +1635,27 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/cytoscape-cola": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.5.1.tgz",
+      "integrity": "sha512-4/2S9bW1LvdsEPmxXN1OEAPFPbk7DvCx2c9d+TblkQAAvptGaSgtPWCByTEGgT8UxCxcVqes2aFPO5pzwo7R2w==",
+      "license": "MIT",
+      "dependencies": {
+        "webcola": "^3.4.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-euler": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cytoscape-euler/-/cytoscape-euler-1.2.3.tgz",
+      "integrity": "sha512-HLdmjmO9br5SMQK+SPt5Hfn2JC6MLpvBkLNBxQHsl30bLPnWEHdaTlMapWP2HZR9G56+DuELf9FbxjEGYFWIMA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "cytoscape": "^3.0.0"
+      }
+    },
     "node_modules/cytoscape-fcose": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
@@ -1643,6 +1667,61 @@
       "peerDependencies": {
         "cytoscape": "^3.2.0"
       }
+    },
+    "node_modules/cytoscape-spread": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-spread/-/cytoscape-spread-3.0.0.tgz",
+      "integrity": "sha512-ekuo4ByFRTZ4TOJylE2bPOMcVVyi8rD+qjvEjMWS2BHcyan40pmhlA4ramz/nTxZR+EtlxEa1asnmfiN8R5HyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "weaverjs": "^1.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.0.0"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -3753,6 +3832,27 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/weaverjs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/weaverjs/-/weaverjs-1.2.0.tgz",
+      "integrity": "sha512-X+nDGl5mrc8ysArmafu6dD3GNFP2r+NdV6L/PiWac8TpH4BVODO/HMaPLhrXmOZhdI3XM0LVxW5ZrAbwKqkkmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/webcola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
+      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-drag": "^1.0.4",
+        "d3-shape": "^1.3.5",
+        "d3-timer": "^1.0.5"
       }
     },
     "node_modules/webidl-conversions": {

--- a/nwleaderboard-ui/package.json
+++ b/nwleaderboard-ui/package.json
@@ -12,7 +12,10 @@
     "@babel/standalone": "^7.28.1",
     "chart.js": "^4.5.0",
     "cytoscape": "^3.27.0",
+    "cytoscape-cola": "^2.5.1",
+    "cytoscape-euler": "^1.2.3",
     "cytoscape-fcose": "^2.2.0",
+    "cytoscape-spread": "^3.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.0"

--- a/nwleaderboard-ui/public/index.html
+++ b/nwleaderboard-ui/public/index.html
@@ -37,6 +37,14 @@
     <script src="/vendor/cytoscape.umd.js"></script>
     <script src="/vendor/layout-base.js"></script>
     <script src="/vendor/cose-base.js"></script>
+    <script src="/vendor/cola.min.js"></script>
+    <script>
+      window.webcola = window.webcola || window.cola;
+    </script>
+    <script src="/vendor/cytoscape-cola.js"></script>
+    <script src="/vendor/cytoscape-euler.js"></script>
+    <script src="/vendor/weaver.min.js"></script>
+    <script src="/vendor/cytoscape-spread.js"></script>
     <script src="/vendor/cytoscape-fcose.js"></script>
     <script type="module" src="/js/index.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add layout selection controls to the relationship graph page and rerun Cytoscape with the chosen layout
- bundle additional Cytoscape layout extensions and dependencies for cola, euler, and spread layouts
- style the layout selector buttons to integrate with the existing relationship page actions

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68de50c4be54832cbbcd0ce1ea6c8312