### PR TITLE
Switch relationship graph to cola layout

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerRelationshipGraphResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerRelationshipGraphResponse.java
@@ -6,14 +6,10 @@ import java.util.List;
  * Response payload describing the relationship graph for a player.
  */
 public record PlayerRelationshipGraphResponse(
-        PlayerRelationshipNodeResponse origin,
-        List<PlayerRelationshipNodeResponse> alternates,
-        List<PlayerRelationshipNodeResponse> relatedPlayers,
-        List<PlayerRelationshipEdgeResponse> edges) {
+        List<PlayerRelationshipNodeResponse> nodes, List<PlayerRelationshipEdgeResponse> edges) {
 
     public PlayerRelationshipGraphResponse {
-        alternates = alternates == null ? List.of() : List.copyOf(alternates);
-        relatedPlayers = relatedPlayers == null ? List.of() : List.copyOf(relatedPlayers);
+        nodes = nodes == null ? List.of() : List.copyOf(nodes);
         edges = edges == null ? List.of() : List.copyOf(edges);
     }
 }

--- a/nwleaderboard-ui/build.js
+++ b/nwleaderboard-ui/build.js
@@ -50,6 +50,8 @@ cpSync('node_modules/cytoscape/dist/cytoscape.umd.js', 'dist/vendor/cytoscape.um
 cpSync('node_modules/layout-base/layout-base.js', 'dist/vendor/layout-base.js');
 cpSync('node_modules/cose-base/cose-base.js', 'dist/vendor/cose-base.js');
 cpSync('node_modules/cytoscape-fcose/cytoscape-fcose.js', 'dist/vendor/cytoscape-fcose.js');
+cpSync('node_modules/webcola/WebCola/cola.min.js', 'dist/vendor/cola.min.js');
+cpSync('node_modules/cytoscape-cola/cytoscape-cola.js', 'dist/vendor/cytoscape-cola.js');
 
 let version = '';
 const tag = process.env.GITHUB_REF_NAME || process.env.GIT_TAG || process.env.TAG;

--- a/nwleaderboard-ui/js/pages/Relationship.js
+++ b/nwleaderboard-ui/js/pages/Relationship.js
@@ -158,12 +158,8 @@ function mergeGraphData(previous, ownerId, payload, t) {
   }
 
   if (payload && typeof payload === 'object') {
-    registerNode(payload.origin);
-    if (Array.isArray(payload.alternates)) {
-      payload.alternates.forEach(registerNode);
-    }
-    if (Array.isArray(payload.relatedPlayers)) {
-      payload.relatedPlayers.forEach(registerNode);
+    if (Array.isArray(payload.nodes)) {
+      payload.nodes.forEach(registerNode);
     }
     if (Array.isArray(payload.edges)) {
       payload.edges.forEach(registerEdge);
@@ -318,7 +314,7 @@ export default function Relationship() {
   const [cyUnavailable, setCyUnavailable] = React.useState(false);
   const containerRef = React.useRef(null);
   const cyRef = React.useRef(null);
-  const layoutNameRef = React.useRef('cose');
+  const layoutNameRef = React.useRef('cola');
 
   React.useEffect(() => {
     graphRef.current = graphData;
@@ -348,18 +344,18 @@ export default function Relationship() {
       setCyUnavailable(true);
       return undefined;
     }
-    let fcoseAvailable = false;
+    let colaAvailable = false;
     if (typeof cytoscapeLib.extension === 'function' && typeof cytoscapeLib.use === 'function') {
-      fcoseAvailable = Boolean(cytoscapeLib.extension('layout', 'fcose'));
-      if (!fcoseAvailable) {
-        const fcose = window.cytoscapeFcose;
-        if (typeof fcose === 'function') {
-          cytoscapeLib.use(fcose);
-          fcoseAvailable = Boolean(cytoscapeLib.extension('layout', 'fcose'));
+      colaAvailable = Boolean(cytoscapeLib.extension('layout', 'cola'));
+      if (!colaAvailable) {
+        const cola = window.cytoscapeCola;
+        if (typeof cola === 'function') {
+          cytoscapeLib.use(cola);
+          colaAvailable = Boolean(cytoscapeLib.extension('layout', 'cola'));
         }
       }
     }
-    layoutNameRef.current = fcoseAvailable ? 'fcose' : 'cose';
+    layoutNameRef.current = colaAvailable ? 'cola' : 'cose';
     if (!containerRef.current) {
       return undefined;
     }
@@ -553,6 +549,7 @@ export default function Relationship() {
         width,
         label,
         alternateLink: edge.alternate ? 1 : 0,
+        runCount: edge.runCount !== null && edge.runCount !== undefined ? edge.runCount : 0,
       };
       const existing = cy.getElementById(id);
       if (existing && existing.nonempty()) {
@@ -567,25 +564,26 @@ export default function Relationship() {
       name: layoutName,
       animate: false,
       fit: true,
-      padding: layoutName === 'fcose' ? 240 : 220,
+      padding: layoutName === 'cola' ? 260 : 220,
     };
-    if (layoutName === 'fcose') {
+    if (layoutName === 'cola') {
       Object.assign(layoutOptions, {
-        quality: 'proof',
+        refresh: 0.5,
+        maxSimulationTime: 4000,
         randomize: false,
+        avoidOverlap: true,
+        nodeSpacing: 24,
         nodeDimensionsIncludeLabels: true,
-        packComponents: true,
-        nodeRepulsion: 130000,
-        nodeSeparation: 150,
-        idealEdgeLength: 380,
-        edgeElasticity: 0.07,
-        gravity: 0.2,
-        gravityRange: 3.4,
-        gravityCompound: 0.7,
-        gravityRangeCompound: 3,
-        tilingPaddingHorizontal: 112,
-        tilingPaddingVertical: 112,
-        numIter: 2500,
+        handleDisconnected: true,
+        flow: undefined,
+        edgeLength: (edge) => {
+          const count = toNumeric(edge.data('runCount'));
+          if (!Number.isFinite(count) || count <= 0) {
+            return 260;
+          }
+          const reduction = Math.min(Math.log10(count + 1) * 36, 140);
+          return Math.max(260 - reduction, 120);
+        },
       });
     } else {
       Object.assign(layoutOptions, {

--- a/nwleaderboard-ui/package-lock.json
+++ b/nwleaderboard-ui/package-lock.json
@@ -11,10 +11,12 @@
         "@babel/standalone": "^7.28.1",
         "chart.js": "^4.5.0",
         "cytoscape": "^3.27.0",
+        "cytoscape-cola": "^2.5.1",
         "cytoscape-fcose": "^2.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.23.0"
+        "react-router-dom": "^6.23.0",
+        "webcola": "^3.4.0"
       },
       "devDependencies": {
         "@bubblewrap/cli": "^1.23.0"
@@ -1632,6 +1634,18 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/cytoscape-cola": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.5.1.tgz",
+      "integrity": "sha512-4/2S9bW1LvdsEPmxXN1OEAPFPbk7DvCx2c9d+TblkQAAvptGaSgtPWCByTEGgT8UxCxcVqes2aFPO5pzwo7R2w==",
+      "license": "MIT",
+      "dependencies": {
+        "webcola": "^3.4.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
     "node_modules/cytoscape-fcose": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
@@ -1643,6 +1657,49 @@
       "peerDependencies": {
         "cytoscape": "^3.2.0"
       }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -3753,6 +3810,18 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webcola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
+      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-drag": "^1.0.4",
+        "d3-shape": "^1.3.5",
+        "d3-timer": "^1.0.5"
       }
     },
     "node_modules/webidl-conversions": {

--- a/nwleaderboard-ui/package.json
+++ b/nwleaderboard-ui/package.json
@@ -12,10 +12,12 @@
     "@babel/standalone": "^7.28.1",
     "chart.js": "^4.5.0",
     "cytoscape": "^3.27.0",
+    "cytoscape-cola": "^2.5.1",
     "cytoscape-fcose": "^2.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "webcola": "^3.4.0"
   },
   "devDependencies": {
     "@bubblewrap/cli": "^1.23.0"

--- a/nwleaderboard-ui/public/index.html
+++ b/nwleaderboard-ui/public/index.html
@@ -35,9 +35,11 @@
     <script src="/vendor/react-router-dom.development.js"></script>
     <script src="/vendor/chart.umd.js"></script>
     <script src="/vendor/cytoscape.umd.js"></script>
+    <script src="/vendor/cola.min.js"></script>
     <script src="/vendor/layout-base.js"></script>
     <script src="/vendor/cose-base.js"></script>
     <script src="/vendor/cytoscape-fcose.js"></script>
+    <script src="/vendor/cytoscape-cola.js"></script>
     <script type="module" src="/js/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- return relationship graph nodes and edges in a single list from the API to align with the Cytoscape cola layout requirements
- add the cytoscape-cola/webcola dependencies and bundle their scripts for the relationship page
- update the relationship page to prefer the cola layout with custom edge lengths driven by run counts

## Testing
- npm run build
- mvn -f nwleaderboard-api/pom.xml -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68debe86a730832ca9be7a8cea201bcc