### PR TITLE
Switch relationship graph to WebCola layout

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerRelationshipGraphResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/PlayerRelationshipGraphResponse.java
@@ -6,14 +6,10 @@ import java.util.List;
  * Response payload describing the relationship graph for a player.
  */
 public record PlayerRelationshipGraphResponse(
-        PlayerRelationshipNodeResponse origin,
-        List<PlayerRelationshipNodeResponse> alternates,
-        List<PlayerRelationshipNodeResponse> relatedPlayers,
-        List<PlayerRelationshipEdgeResponse> edges) {
+        List<PlayerRelationshipNodeResponse> nodes, List<PlayerRelationshipEdgeResponse> edges) {
 
     public PlayerRelationshipGraphResponse {
-        alternates = alternates == null ? List.of() : List.copyOf(alternates);
-        relatedPlayers = relatedPlayers == null ? List.of() : List.copyOf(relatedPlayers);
+        nodes = nodes == null ? List.of() : List.copyOf(nodes);
         edges = edges == null ? List.of() : List.copyOf(edges);
     }
 }

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/PlayerRelationshipService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/PlayerRelationshipService.java
@@ -156,8 +156,25 @@ public class PlayerRelationshipService {
             }
         }
 
+        Map<Long, PlayerRelationshipNodeResponse> indexedNodes = new LinkedHashMap<>();
+        if (originNode != null && originNode.playerId() != null) {
+            indexedNodes.put(originNode.playerId(), originNode);
+        }
+        for (PlayerRelationshipNodeResponse node : alternateNodes) {
+            if (node == null || node.playerId() == null) {
+                continue;
+            }
+            indexedNodes.putIfAbsent(node.playerId(), node);
+        }
+        for (PlayerRelationshipNodeResponse node : relatedNodes) {
+            if (node == null || node.playerId() == null) {
+                continue;
+            }
+            indexedNodes.put(node.playerId(), node);
+        }
+
         PlayerRelationshipGraphResponse response =
-                new PlayerRelationshipGraphResponse(originNode, alternateNodes, relatedNodes, edges);
+                new PlayerRelationshipGraphResponse(List.copyOf(indexedNodes.values()), edges);
         return Optional.of(response);
     }
 

--- a/nwleaderboard-ui/build.js
+++ b/nwleaderboard-ui/build.js
@@ -50,6 +50,8 @@ cpSync('node_modules/cytoscape/dist/cytoscape.umd.js', 'dist/vendor/cytoscape.um
 cpSync('node_modules/layout-base/layout-base.js', 'dist/vendor/layout-base.js');
 cpSync('node_modules/cose-base/cose-base.js', 'dist/vendor/cose-base.js');
 cpSync('node_modules/cytoscape-fcose/cytoscape-fcose.js', 'dist/vendor/cytoscape-fcose.js');
+cpSync('node_modules/webcola/WebCola/cola.min.js', 'dist/vendor/cola.min.js');
+cpSync('node_modules/cytoscape-cola/cytoscape-cola.js', 'dist/vendor/cytoscape-cola.js');
 
 let version = '';
 const tag = process.env.GITHUB_REF_NAME || process.env.GIT_TAG || process.env.TAG;

--- a/nwleaderboard-ui/package-lock.json
+++ b/nwleaderboard-ui/package-lock.json
@@ -11,10 +11,12 @@
         "@babel/standalone": "^7.28.1",
         "chart.js": "^4.5.0",
         "cytoscape": "^3.27.0",
+        "cytoscape-cola": "^2.5.1",
         "cytoscape-fcose": "^2.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.23.0"
+        "react-router-dom": "^6.23.0",
+        "webcola": "^3.4.0"
       },
       "devDependencies": {
         "@bubblewrap/cli": "^1.23.0"
@@ -1632,6 +1634,18 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/cytoscape-cola": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/cytoscape-cola/-/cytoscape-cola-2.5.1.tgz",
+      "integrity": "sha512-4/2S9bW1LvdsEPmxXN1OEAPFPbk7DvCx2c9d+TblkQAAvptGaSgtPWCByTEGgT8UxCxcVqes2aFPO5pzwo7R2w==",
+      "license": "MIT",
+      "dependencies": {
+        "webcola": "^3.4.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
     "node_modules/cytoscape-fcose": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
@@ -1643,6 +1657,49 @@
       "peerDependencies": {
         "cytoscape": "^3.2.0"
       }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.5.tgz",
+      "integrity": "sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1",
+        "d3-selection": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-selection": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
+      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -3753,6 +3810,18 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webcola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
+      "integrity": "sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3",
+        "d3-drag": "^1.0.4",
+        "d3-shape": "^1.3.5",
+        "d3-timer": "^1.0.5"
       }
     },
     "node_modules/webidl-conversions": {

--- a/nwleaderboard-ui/package.json
+++ b/nwleaderboard-ui/package.json
@@ -12,10 +12,12 @@
     "@babel/standalone": "^7.28.1",
     "chart.js": "^4.5.0",
     "cytoscape": "^3.27.0",
+    "cytoscape-cola": "^2.5.1",
     "cytoscape-fcose": "^2.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "webcola": "^3.4.0"
   },
   "devDependencies": {
     "@bubblewrap/cli": "^1.23.0"

--- a/nwleaderboard-ui/public/index.html
+++ b/nwleaderboard-ui/public/index.html
@@ -35,6 +35,8 @@
     <script src="/vendor/react-router-dom.development.js"></script>
     <script src="/vendor/chart.umd.js"></script>
     <script src="/vendor/cytoscape.umd.js"></script>
+    <script src="/vendor/cola.min.js"></script>
+    <script src="/vendor/cytoscape-cola.js"></script>
     <script src="/vendor/layout-base.js"></script>
     <script src="/vendor/cose-base.js"></script>
     <script src="/vendor/cytoscape-fcose.js"></script>


### PR DESCRIPTION
## Summary
- add the cytoscape-cola/webcola assets to the UI build so the relationship graph can use the WebCola layout
- update the relationship page to consume the new relationship payload shape and run the Cola layout
- restructure the relationship API response to expose a single node list compatible with the new layout

## Testing
- npm run build
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68debe86a730832ca9be7a8cea201bcc