### PR TITLE
Expand relationship graph modal to occupy more screen space

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2904,14 +2904,16 @@ body[data-theme='light'] .player-chart-card {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem clamp(1rem, 5vw, 3rem);
+  padding: 5vh 5vw;
   z-index: 1200;
   backdrop-filter: blur(6px);
 }
 
 .player-relationship-modal-card {
-  width: min(90vw, 1200px);
-  height: min(90vh, 720px);
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
   background: var(--surface-dark);
   border-radius: 22px;
   border: 1px solid var(--border-dark);


### PR DESCRIPTION
## Summary
- expand the relationship graph modal to fill the viewport while maintaining a 5% margin
- ensure the modal card uses the full padded area for a larger graph display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e035db5b6c832cb1c2fa70f5028204