### PR TITLE
Adjust relationship graph fullscreen button position

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2771,6 +2771,17 @@ body[data-theme='light'] .player-chart-card {
   margin: 2rem 0 1.5rem;
 }
 
+.player-relationship-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.player-relationship-header .player-chart-title {
+  flex: 1 1 auto;
+}
+
 .player-relationship-body {
   height: clamp(320px, 48vw, 460px);
   min-height: 320px;
@@ -2793,14 +2804,11 @@ body[data-theme='light'] .player-chart-card {
 }
 
 .player-relationship-tools {
-  position: absolute;
-  top: 0;
-  right: 0;
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
+  justify-content: flex-end;
   gap: 0.6rem;
-  z-index: 2;
+  margin-left: auto;
 }
 
 .player-relationship-modal-toggle,

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -2794,8 +2794,8 @@ body[data-theme='light'] .player-chart-card {
 
 .player-relationship-tools {
   position: absolute;
-  top: 0.85rem;
-  right: 0.85rem;
+  top: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: flex-end;

--- a/nwleaderboard-ui/js/pages/Player.js
+++ b/nwleaderboard-ui/js/pages/Player.js
@@ -1787,6 +1787,19 @@ export default function Player({ canContribute = false }) {
     return 'No relationship data available yet.';
   }, [t]);
 
+  const canExpandRelationshipGraph = React.useMemo(() => {
+    if (!Array.isArray(relationshipElements)) {
+      return false;
+    }
+    if (relationshipElements.length === 0) {
+      return false;
+    }
+    if (relationshipLoading || relationshipError) {
+      return false;
+    }
+    return true;
+  }, [relationshipElements, relationshipError, relationshipLoading]);
+
   const relationshipAriaLabel = React.useMemo(() => {
     const fallbackName = (() => {
       if (playerPrimaryName) {
@@ -2544,7 +2557,22 @@ export default function Player({ canContribute = false }) {
                   </div>
                 ) : null}
                 <section className={relationshipCardClassName}>
-                  <h2 className="player-chart-title">{relationshipTitle}</h2>
+                  <div className="player-relationship-header">
+                    <h2 className="player-chart-title">{relationshipTitle}</h2>
+                    {canExpandRelationshipGraph ? (
+                      <div className="player-relationship-tools">
+                        <button
+                          type="button"
+                          className="player-relationship-modal-toggle"
+                          onClick={handleRelationshipModalOpen}
+                          aria-label={relationshipExpandLabel}
+                          title={relationshipExpandTitle}
+                        >
+                          <ExpandIcon className="player-relationship-modal-toggle-icon" />
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
                   <div className="player-chart-body player-relationship-body">
                     {relationshipLoading ? (
                       <p className="player-relationship-status">{relationshipLoadingLabel}</p>
@@ -2561,17 +2589,6 @@ export default function Player({ canContribute = false }) {
                             ariaLabel={relationshipAriaLabel}
                             className="player-relationship-graph-canvas"
                           />
-                          <div className="player-relationship-tools">
-                            <button
-                              type="button"
-                              className="player-relationship-modal-toggle"
-                              onClick={handleRelationshipModalOpen}
-                              aria-label={relationshipExpandLabel}
-                              title={relationshipExpandTitle}
-                            >
-                              <ExpandIcon className="player-relationship-modal-toggle-icon" />
-                            </button>
-                          </div>
                         </div>
                         {!showRelationshipModal && (showRelationshipSlider || showRelationshipLayoutControls) ? (
                           <div className="player-relationship-controls">


### PR DESCRIPTION
## Summary
- move the relationship graph fullscreen button container to the top-right corner to align with the card edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04c281520832ca5abed93d91cd296