### PR TITLE
Filter relationship graph runs by season

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/PlayerResource.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/PlayerResource.java
@@ -85,8 +85,10 @@ public class PlayerResource {
 
     @GET
     @Path("/{playerId}/relationships")
-    public Response getRelationships(@PathParam("playerId") Long playerId) {
-        Optional<PlayerRelationshipGraphResponse> graph = playerRelationshipService.getRelationships(playerId);
+    public Response getRelationships(
+            @PathParam("playerId") Long playerId, @QueryParam("seasonId") Integer seasonId) {
+        Optional<PlayerRelationshipGraphResponse> graph =
+                playerRelationshipService.getRelationships(playerId, seasonId);
         if (graph.isEmpty()) {
             return Response.status(Status.NOT_FOUND)
                     .entity(new ApiMessageResponse("player not found", null))


### PR DESCRIPTION
## Summary
- accept an optional `seasonId` query parameter on the player relationships endpoint
- filter relationship run aggregation by the selected season and use the season when requesting the graph in the UI
- hide shared-run labels on main-to-alt relationship edges in the player relationship graph

## Testing
- mvn -f nwleaderboard-api/pom.xml test

------
https://chatgpt.com/codex/tasks/task_e_68e04c868f20832cb1c1d458f353a237