### PR TITLE
Improve mobile navigation and responsiveness

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -52,6 +52,10 @@ body {
   overflow-x: hidden;
 }
 
+body.site-nav-open {
+  overflow: hidden;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -175,6 +179,16 @@ body[data-theme='light'] .site-header__title {
   flex: 1 1 auto;
   justify-content: flex-end;
   min-width: clamp(16rem, 50%, 28rem);
+  position: relative;
+}
+
+.site-nav__panel {
+  width: 100%;
+  display: flex;
+}
+
+.site-nav__overlay {
+  display: none;
 }
 
 .site-nav__sections {
@@ -367,6 +381,77 @@ body[data-theme='light'] .site-nav__dropdown-section {
   box-shadow: 0 0 0 2px rgba(124, 92, 255, 0.6);
 }
 
+.site-nav-toggle {
+  display: none;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(12, 18, 32, 0.4);
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.site-nav-toggle:hover,
+.site-nav-toggle:focus-visible {
+  background: rgba(124, 92, 255, 0.2);
+  border-color: rgba(124, 92, 255, 0.5);
+  outline: none;
+}
+
+.site-nav-toggle:focus-visible {
+  box-shadow: 0 0 0 2px rgba(124, 92, 255, 0.6);
+}
+
+.site-nav-toggle__bars,
+.site-nav-toggle__bars::before,
+.site-nav-toggle__bars::after {
+  display: block;
+  width: 1.3rem;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  content: '';
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.site-nav-toggle__bars {
+  position: relative;
+}
+
+.site-nav-toggle__bars::before {
+  position: absolute;
+  top: -0.4rem;
+  left: 0;
+}
+
+.site-nav-toggle__bars::after {
+  position: absolute;
+  bottom: -0.4rem;
+  left: 0;
+}
+
+.site-nav-toggle--open .site-nav-toggle__bars {
+  background-color: transparent;
+}
+
+.site-nav-toggle--open .site-nav-toggle__bars::before {
+  transform: translateY(0.4rem) rotate(45deg);
+}
+
+.site-nav-toggle--open .site-nav-toggle__bars::after {
+  transform: translateY(-0.4rem) rotate(-45deg);
+}
+
+.site-nav-toggle--alone {
+  margin-left: auto;
+}
+
 .site-footer {
   position: fixed;
   left: 0;
@@ -447,21 +532,119 @@ body[data-theme='light'] .site-footer__link:focus-visible {
   color: var(--color-foreground-light);
 }
 
+@media (max-width: 720px) {
+  .site-footer {
+    position: static;
+    padding: 1.25rem 1.35rem 1.75rem;
+    text-align: center;
+  }
+
+  .site-footer__content {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+    text-align: center;
+  }
+
+  .site-footer__brand {
+    justify-content: center;
+  }
+
+  .site-footer__links {
+    justify-content: center;
+    margin-left: 0;
+  }
+}
+
 @media (max-width: 960px) {
-  .site-nav__group {
-    flex-wrap: wrap;
+  .site-header__inner {
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .site-nav {
+    position: fixed;
+    inset: calc(var(--site-header-height, 0px)) 0 0 0;
+    display: block;
+    min-width: 0;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+    z-index: 950;
+  }
+
+  .site-nav--open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .site-nav__overlay {
+    display: block;
+    position: absolute;
+    inset: 0;
+    background: rgba(5, 8, 22, 0.7);
+    backdrop-filter: blur(2px);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  .site-nav--open .site-nav__overlay {
+    opacity: 1;
+  }
+
+  .site-nav__panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(420px, 100%);
+    margin-left: auto;
+    background: rgba(10, 15, 27, 0.96);
+    border-left: 1px solid var(--border-dark);
+    box-shadow: -24px 0 48px rgba(5, 8, 20, 0.6);
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    padding: clamp(1.5rem, 5vw, 2.25rem) clamp(1.25rem, 6vw, 2.25rem)
+      clamp(2.5rem, 8vw, 3rem);
+    display: flex;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .site-nav--open .site-nav__panel {
+    transform: translateX(0);
+  }
+
+  .site-nav-toggle {
+    display: inline-flex;
   }
 
   .site-nav__sections {
     flex-direction: column;
     align-items: stretch;
-    gap: 1.25rem;
+    gap: clamp(1.5rem, 4vw, 2rem);
+  }
+
+  .site-nav__group {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
   }
 
   .site-nav__group--left,
   .site-nav__group--right {
-    flex: 1 1 100%;
-    justify-content: center;
+    justify-content: flex-start;
+  }
+
+  .site-nav__link {
+    width: 100%;
+    justify-content: flex-start;
+    font-size: clamp(1rem, 4vw, 1.05rem);
+  }
+
+  .site-nav__link--parent {
+    font-size: clamp(1.05rem, 4.2vw, 1.15rem);
   }
 
   .site-nav__dropdown-menu {
@@ -472,30 +655,47 @@ body[data-theme='light'] .site-footer__link:focus-visible {
     pointer-events: auto;
     box-shadow: none;
     background: transparent;
-    padding: 0;
+    padding: 0.75rem 0 0 0;
     border: none;
-    flex-direction: row;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .site-nav__dropdown-section {
+    background: rgba(12, 18, 32, 0.55);
+    padding: 0.75rem;
+    border-radius: 16px;
     gap: 0.5rem;
   }
 
-  body[data-theme='light'] .site-nav__dropdown-menu {
-    background: transparent;
-    box-shadow: none;
+  .site-nav__dropdown-title {
+    font-size: clamp(0.75rem, 3.2vw, 0.85rem);
   }
 
   .site-nav__dropdown-menu .site-nav__link {
+    border-radius: 12px;
     border: 1px solid rgba(148, 163, 184, 0.18);
-    background: rgba(12, 18, 32, 0.35);
-  }
-
-  body[data-theme='light'] .site-nav__dropdown-menu .site-nav__link {
-    background: rgba(246, 248, 255, 0.85);
-    border-color: rgba(148, 163, 184, 0.25);
+    background: rgba(5, 8, 20, 0.45);
+    font-size: clamp(0.95rem, 3.8vw, 1.05rem);
   }
 
   .site-nav__item--dropdown .site-nav__link--parent::after {
     display: none;
+  }
+
+  body[data-theme='light'] .site-nav__panel {
+    background: rgba(246, 248, 255, 0.98);
+    border-left-color: var(--border-light);
+    box-shadow: -24px 0 48px rgba(15, 23, 42, 0.22);
+  }
+
+  body[data-theme='light'] .site-nav__dropdown-section {
+    background: rgba(246, 248, 255, 0.78);
+  }
+
+  body[data-theme='light'] .site-nav__dropdown-menu .site-nav__link {
+    background: rgba(246, 248, 255, 0.88);
+    border-color: rgba(148, 163, 184, 0.25);
   }
 }
 

--- a/nwleaderboard-ui/js/locales/de.js
+++ b/nwleaderboard-ui/js/locales/de.js
@@ -344,6 +344,8 @@ const de = {
   leaderboardMenuTitle: 'Leaderboards',
   leaderboardEmpty: 'Es sind noch keine Scores verfügbar. Schau bald wieder vorbei!',
   navMenu: 'Menü',
+  openMenu: 'Menü öffnen',
+  closeMenu: 'Menü schließen',
   scoreTitle: 'Beste Scores',
   timeTitle: 'Beste Zeiten',
   leaderboardScoreChartTitle: 'Score-Entwicklung pro Woche',

--- a/nwleaderboard-ui/js/locales/en.js
+++ b/nwleaderboard-ui/js/locales/en.js
@@ -346,6 +346,8 @@ const en = {
   leaderboardMenuTitle: 'Leaderboards',
   leaderboardEmpty: 'No scores available yet. Stay tuned!',
   navMenu: 'Menu',
+  openMenu: 'Open menu',
+  closeMenu: 'Close menu',
   scoreTitle: 'Best scores',
   timeTitle: 'Best times',
   leaderboardScoreChartTitle: 'Score progression by week',

--- a/nwleaderboard-ui/js/locales/es.js
+++ b/nwleaderboard-ui/js/locales/es.js
@@ -346,6 +346,8 @@ const es = {
   leaderboardMenuTitle: 'Rankings',
   leaderboardEmpty: 'Todavía no hay puntuaciones. ¡Vuelve pronto!',
   navMenu: 'Menú',
+  openMenu: 'Abrir menú',
+  closeMenu: 'Cerrar menú',
   scoreTitle: 'Mejores puntuaciones',
   timeTitle: 'Mejores tiempos',
   leaderboardScoreChartTitle: 'Evolución de la puntuación por semana',

--- a/nwleaderboard-ui/js/locales/esmx.js
+++ b/nwleaderboard-ui/js/locales/esmx.js
@@ -344,6 +344,8 @@ const esmx = {
   leaderboardMenuTitle: 'Rankings',
   leaderboardEmpty: 'Aún no hay scores disponibles. ¡Vuelve pronto!',
   navMenu: 'Menú',
+  openMenu: 'Abrir menú',
+  closeMenu: 'Cerrar menú',
   scoreTitle: 'Mejores scores',
   timeTitle: 'Mejores tiempos',
   leaderboardScoreChartTitle: 'Progreso del score por semana',

--- a/nwleaderboard-ui/js/locales/fr.js
+++ b/nwleaderboard-ui/js/locales/fr.js
@@ -351,6 +351,8 @@ const fr = {
   leaderboardMenuTitle: 'Classements',
   leaderboardEmpty: 'Aucun score pour le moment. Revenez vite !',
   navMenu: 'Menu',
+  openMenu: 'Ouvrir le menu',
+  closeMenu: 'Fermer le menu',
   scoreTitle: 'Meilleurs scores',
   timeTitle: 'Meilleurs temps',
   leaderboardScoreChartTitle: 'Progression des scores par semaine',

--- a/nwleaderboard-ui/js/locales/it.js
+++ b/nwleaderboard-ui/js/locales/it.js
@@ -344,6 +344,8 @@ const it = {
   leaderboardMenuTitle: 'Leaderboard',
   leaderboardEmpty: 'Ancora nessun punteggio. Torna presto!',
   navMenu: 'Menu',
+  openMenu: 'Apri menu',
+  closeMenu: 'Chiudi menu',
   scoreTitle: 'Migliori punteggi',
   timeTitle: 'Migliori tempi',
   leaderboardScoreChartTitle: 'Andamento punteggio settimanale',

--- a/nwleaderboard-ui/js/locales/pl.js
+++ b/nwleaderboard-ui/js/locales/pl.js
@@ -344,6 +344,8 @@ const pl = {
   leaderboardMenuTitle: 'Leaderboardy',
   leaderboardEmpty: 'Brak wyników. Wróć później!',
   navMenu: 'Menu',
+  openMenu: 'Otwórz menu',
+  closeMenu: 'Zamknij menu',
   scoreTitle: 'Najlepsze wyniki',
   timeTitle: 'Najlepsze czasy',
   leaderboardScoreChartTitle: 'Postęp wyników tygodniowych',

--- a/nwleaderboard-ui/js/locales/pt.js
+++ b/nwleaderboard-ui/js/locales/pt.js
@@ -344,6 +344,8 @@ const pt = {
   leaderboardMenuTitle: 'Leaderboards',
   leaderboardEmpty: 'Ainda não há pontuações disponíveis. Volte em breve!',
   navMenu: 'Menu',
+  openMenu: 'Abrir menu',
+  closeMenu: 'Fechar menu',
   scoreTitle: 'Melhores pontuações',
   timeTitle: 'Melhores tempos',
   leaderboardScoreChartTitle: 'Evolução do score semanal',


### PR DESCRIPTION
## Summary
- add a responsive navigation toggle with layout detection so the menu can collapse into a mobile drawer
- update shared styling to support the drawer, lock body scrolling, and relax the footer layout on small screens
- localize the new navigation toggle labels across all supported languages

## Testing
- npm run build *(fails: node_modules/layout-base/layout-base.js is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0533dd300832caa48e5f0cdbd1129