### PR TITLE
Improve mobile navigation and responsiveness

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -448,6 +448,21 @@ body[data-theme='light'] .site-footer__link:focus-visible {
 }
 
 @media (max-width: 960px) {
+  .site-header__inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .site-header__brand {
+    justify-content: center;
+    width: 100%;
+  }
+
+  .site-nav {
+    display: none;
+  }
+
   .site-nav__group {
     flex-wrap: wrap;
   }
@@ -496,6 +511,24 @@ body[data-theme='light'] .site-footer__link:focus-visible {
 
   .site-nav__item--dropdown .site-nav__link--parent::after {
     display: none;
+  }
+
+  .bottom-nav {
+    display: flex;
+    align-items: center;
+  }
+
+  .bottom-nav__scroll {
+    margin-right: 0;
+  }
+
+  .bottom-nav-link,
+  .bottom-nav-button {
+    flex: 0 0 auto;
+  }
+
+  .site-footer {
+    padding-bottom: 6rem;
   }
 }
 
@@ -1667,13 +1700,14 @@ body[data-theme='light'] .page-submenu-link.active {
 }
 
 .bottom-nav {
+  display: none;
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
-  display: flex;
   justify-content: space-around;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
   padding: 0.85rem 1.25rem;
   background: rgba(10, 15, 27, 0.85);
@@ -1708,6 +1742,22 @@ body[data-theme='light'] .bottom-nav {
   padding: 0.5rem 0.75rem;
   border-radius: 999px;
   box-shadow: 0 12px 24px rgba(124, 92, 255, 0.35);
+}
+
+.bottom-nav__scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.35rem;
+  margin-right: 0.5rem;
+  scrollbar-width: none;
+}
+
+.bottom-nav__scroll::-webkit-scrollbar {
+  display: none;
 }
 
 .leaderboard-layout {

--- a/nwleaderboard-ui/js/App.js
+++ b/nwleaderboard-ui/js/App.js
@@ -21,6 +21,7 @@ import Suggestions from './pages/Suggestions.js';
 import VersionChecker from './VersionChecker.js';
 import Header from './Header.js';
 import Footer from './Footer.js';
+import BottomNav from './BottomNav.js';
 import {
   storeTokens,
   clearTokens,
@@ -144,6 +145,11 @@ export default function App() {
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </main>
+          <BottomNav
+            authenticated={authenticated}
+            canContribute={authState.canContribute}
+            onLogout={handleLogout}
+          />
           <Footer />
         </div>
       </BrowserRouter>

--- a/nwleaderboard-ui/js/BottomNav.js
+++ b/nwleaderboard-ui/js/BottomNav.js
@@ -2,10 +2,10 @@ import { LangContext } from './i18n.js';
 
 const { NavLink } = ReactRouterDOM;
 
-function NavButton({ to, children, onClick }) {
+function NavButton({ to, children, onClick, end = true }) {
   if (to) {
     return (
-      <NavLink className="bottom-nav-link" to={to} end>
+      <NavLink className="bottom-nav-link" to={to} end={end}>
         {({ isActive }) => (
           <span className={isActive ? 'active' : undefined}>{children}</span>
         )}
@@ -24,6 +24,17 @@ export default function BottomNav({ authenticated, canContribute = false, onLogo
   const isAuthenticated = Boolean(authenticated);
   const showContribute = isAuthenticated && Boolean(canContribute);
 
+  const primaryNavigation = React.useMemo(
+    () => [
+      { to: '/', label: t.home, end: true },
+      { to: '/score', label: t.score, end: true },
+      { to: '/time', label: t.time, end: true },
+      { to: '/individual', label: t.individual, end: true },
+      { to: '/player', label: t.players || t.player, end: false },
+    ],
+    [t],
+  );
+
   const accountNavigation = isAuthenticated ? (
     <>
       {showContribute ? <NavButton to="/contribute">{t.contribute}</NavButton> : null}
@@ -39,7 +50,13 @@ export default function BottomNav({ authenticated, canContribute = false, onLogo
 
   return (
     <nav className="bottom-nav" aria-label={t.navMenu}>
-      <NavButton to="/">{t.home}</NavButton>
+      <div className="bottom-nav__scroll">
+        {primaryNavigation.map((item) => (
+          <NavButton key={item.to} to={item.to} end={item.end}>
+            {item.label}
+          </NavButton>
+        ))}
+      </div>
       {accountNavigation}
     </nav>
   );


### PR DESCRIPTION
## Summary
- add a dedicated bottom navigation bar for small screens with quick links to the main sections
- adjust the header and footer layout so pages render comfortably on mobile viewports
- keep the site branding visible on mobile while wiring the new navigation into the application shell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0533dd300832caa48e5f0cdbd1129