### PR TITLE
Add total-runs mode to individual leaderboard

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/IndividualRankingService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/IndividualRankingService.java
@@ -52,7 +52,8 @@ public class IndividualRankingService {
     public enum Mode {
         GLOBAL,
         SCORE,
-        TIME;
+        TIME,
+        TOTAL_RUNS;
 
         public static Mode fromQuery(String value) {
             if (value == null || value.isBlank()) {
@@ -80,8 +81,9 @@ public class IndividualRankingService {
                 computeScorePlacements(playerNames, playerRegions, allowedWeeks);
         Map<Long, Map<Integer, Integer>> timePlacements =
                 computeTimePlacements(playerNames, playerRegions, allowedWeeks);
+        Map<Long, Integer> totalRunsByPlayer = computeTotalRuns(playerNames, playerRegions, allowedWeeks);
 
-        if (scorePlacements.isEmpty() && timePlacements.isEmpty()) {
+        if (scorePlacements.isEmpty() && timePlacements.isEmpty() && totalRunsByPlayer.isEmpty()) {
             return List.of();
         }
 
@@ -103,6 +105,14 @@ public class IndividualRankingService {
                     .sum();
             points.timePoints = totalPoints;
             points.timePlacements = placementsByWeek;
+        });
+
+        totalRunsByPlayer.forEach((playerId, runCount) -> {
+            if (playerId == null || runCount == null || runCount <= 0) {
+                return;
+            }
+            PlayerPoints points = aggregates.computeIfAbsent(playerId, id -> new PlayerPoints());
+            points.totalRuns = runCount;
         });
 
         aggregates.forEach((playerId, points) -> {
@@ -144,6 +154,7 @@ public class IndividualRankingService {
                 case GLOBAL -> points.globalPoints;
                 case SCORE -> points.scorePoints;
                 case TIME -> points.timePoints;
+                case TOTAL_RUNS -> points.totalRuns;
             };
             if (selectedPoints <= 0) {
                 return;
@@ -402,6 +413,75 @@ public class IndividualRankingService {
         return placements;
     }
 
+    private Map<Long, Integer> computeTotalRuns(
+            Map<Long, String> playerNames, Map<Long, String> playerRegions, Set<Integer> allowedWeeks) {
+        Map<Long, Integer> runCounts = new HashMap<>();
+
+        List<RunScore> scoreRuns = runScoreRepository.find("ORDER BY id ASC").list();
+        if (!scoreRuns.isEmpty()) {
+            Map<Long, List<Player>> playersByRun = loadPlayersForScoreRuns(scoreRuns);
+            for (RunScore run : scoreRuns) {
+                if (run == null || run.getId() == null || !isWeekAllowed(run.getWeek(), allowedWeeks)) {
+                    continue;
+                }
+                List<Player> players = playersByRun.getOrDefault(run.getId(), List.of());
+                if (players.isEmpty()) {
+                    continue;
+                }
+                Set<Long> processed = new HashSet<>();
+                for (Player player : players) {
+                    Player main = resolveMain(player);
+                    if (main == null || main.getId() == null) {
+                        continue;
+                    }
+                    Long mainId = main.getId();
+                    if (!processed.add(mainId)) {
+                        continue;
+                    }
+                    playerNames.merge(mainId, normaliseName(main.getPlayerName()), IndividualRankingService::preferNonEmpty);
+                    String regionId = normaliseRegionId(main.getRegion() != null ? main.getRegion().getId() : null);
+                    if (regionId != null) {
+                        playerRegions.putIfAbsent(mainId, regionId);
+                    }
+                    runCounts.merge(mainId, 1, Integer::sum);
+                }
+            }
+        }
+
+        List<RunTime> timeRuns = runTimeRepository.find("ORDER BY id ASC").list();
+        if (!timeRuns.isEmpty()) {
+            Map<Long, List<Player>> playersByRun = loadPlayersForTimeRuns(timeRuns);
+            for (RunTime run : timeRuns) {
+                if (run == null || run.getId() == null || !isWeekAllowed(run.getWeek(), allowedWeeks)) {
+                    continue;
+                }
+                List<Player> players = playersByRun.getOrDefault(run.getId(), List.of());
+                if (players.isEmpty()) {
+                    continue;
+                }
+                Set<Long> processed = new HashSet<>();
+                for (Player player : players) {
+                    Player main = resolveMain(player);
+                    if (main == null || main.getId() == null) {
+                        continue;
+                    }
+                    Long mainId = main.getId();
+                    if (!processed.add(mainId)) {
+                        continue;
+                    }
+                    playerNames.merge(mainId, normaliseName(main.getPlayerName()), IndividualRankingService::preferNonEmpty);
+                    String regionId = normaliseRegionId(main.getRegion() != null ? main.getRegion().getId() : null);
+                    if (regionId != null) {
+                        playerRegions.putIfAbsent(mainId, regionId);
+                    }
+                    runCounts.merge(mainId, 1, Integer::sum);
+                }
+            }
+        }
+
+        return runCounts;
+    }
+
     private Map<Long, List<Player>> loadPlayersForScoreRuns(List<RunScore> runs) {
         List<Long> runIds = runs.stream()
                 .filter(Objects::nonNull)
@@ -523,5 +603,6 @@ public class IndividualRankingService {
         private int timePoints;
         private Map<Integer, Integer> scorePlacements;
         private Map<Integer, Integer> timePlacements;
+        private int totalRuns;
     }
 }

--- a/nwleaderboard-ui/js/pages/Individual.js
+++ b/nwleaderboard-ui/js/pages/Individual.js
@@ -12,7 +12,7 @@ const { Link } = ReactRouterDOM;
 
 const API_BASE_URL = (window.CONFIG?.['nwleaderboard-api-url'] || '').replace(/\/$/, '');
 
-const MODES = ['global', 'score', 'time'];
+const MODES = ['global', 'score', 'time', 'total_runs'];
 
 function formatPoints(value) {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
@@ -252,7 +252,9 @@ export default function Individual() {
                 ? t.individualModeGlobal
                 : value === 'score'
                 ? t.individualModeScore
-                : t.individualModeTime;
+                : value === 'time'
+                ? t.individualModeTime
+                : t.individualModeTotalRuns || 'Total runs';
             return (
               <button
                 key={value}
@@ -315,6 +317,8 @@ export default function Individual() {
                       ? t.individualScorePointsHeader
                       : mode === 'time'
                       ? t.individualTimePointsHeader
+                      : mode === 'total_runs'
+                      ? t.individualTotalRunsHeader || 'Total runs'
                       : t.individualPointsHeader}
                   </th>
                 </tr>
@@ -329,7 +333,13 @@ export default function Individual() {
                   const scorePoints = Number.isFinite(entry?.scorePoints) ? entry.scorePoints : 0;
                   const timePoints = Number.isFinite(entry?.timePoints) ? entry.timePoints : 0;
                   const pointsForMode =
-                    mode === 'score' ? scorePoints : mode === 'time' ? timePoints : basePoints;
+                    mode === 'score'
+                      ? scorePoints
+                      : mode === 'time'
+                      ? timePoints
+                      : mode === 'total_runs'
+                      ? basePoints
+                      : basePoints;
                   const regionId = extractRegionId(entry);
                   const regionLabel = regionId ? translateRegion(t, regionId) : '—';
                   return (


### PR DESCRIPTION
### Motivation
- Provide a new individual leaderboard view that shows the total number of runs (score + time) per main character using the same filters (season/week/region) as the existing Individual leaderboard.

### Description
- Add a new `TOTAL_RUNS` mode to `IndividualRankingService` and accept `mode=total_runs` when computing the ranking.
- Implement `computeTotalRuns(...)` to count participation across score and time runs while reusing main-character resolution and region/name normalization, and aggregate the count into `PlayerPoints.totalRuns`.
- Include `TOTAL_RUNS` in the selection logic so the API returns entries with `points` set to the total run count for that mode without changing the response shape, and update the UI `Individual` page to add `total_runs` to `MODES`, label fallbacks, and display the appropriate column.

### Testing
- Built the API with `cd nwleaderboard-api && mvn -DskipTests compile` and the compilation completed successfully.
- Built the UI with `cd nwleaderboard-ui && npm run build` and the frontend bundle completed successfully.
- No new automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2165bc10c832c9760a3a44529f719)