### PR TITLE
Add auto-rotating highlights carousel on Home page

### DIFF
--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1566,6 +1566,7 @@ body[data-theme='light'] .suggestion-item__details {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  overflow-x: hidden;
 }
 
 .highlight-carousel-header {
@@ -1620,6 +1621,43 @@ body[data-theme='light'] .suggestion-item__details {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.highlight-list--carousel {
+  will-change: transform, opacity;
+  animation-duration: 460ms;
+  animation-timing-function: ease;
+  animation-fill-mode: both;
+}
+
+.highlight-list--forward {
+  animation-name: highlight-slide-forward;
+}
+
+.highlight-list--backward {
+  animation-name: highlight-slide-backward;
+}
+
+@keyframes highlight-slide-forward {
+  from {
+    opacity: 0;
+    transform: translateX(3.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes highlight-slide-backward {
+  from {
+    opacity: 0;
+    transform: translateX(-3.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .highlight-item {

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1596,6 +1596,9 @@ body[data-theme='light'] .suggestion-item__details {
   height: 0.55rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.35);
+  border: 0;
+  padding: 0;
+  cursor: pointer;
 }
 
 .highlight-carousel-dot.active {

--- a/nwleaderboard-ui/css/main.css
+++ b/nwleaderboard-ui/css/main.css
@@ -1568,6 +1568,40 @@ body[data-theme='light'] .suggestion-item__details {
   gap: 1.5rem;
 }
 
+.highlight-carousel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.highlight-carousel-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(240, 242, 255, 0.82);
+}
+
+.highlight-carousel-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.highlight-carousel-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.highlight-carousel-dot.active {
+  background: #8f82ff;
+  box-shadow: 0 0 0 0.15rem rgba(143, 130, 255, 0.2);
+}
+
 .highlight-status {
   text-align: center;
   padding: 2rem;

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -196,6 +196,7 @@ function formatTime(seconds) {
 export default function Home() {
   const { t, lang } = React.useContext(LangContext);
   const [highlights, setHighlights] = React.useState([]);
+  const [carouselPage, setCarouselPage] = React.useState(0);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(false);
   const pageTitle = capitaliseWords(t.leaderboardTitle || '');
@@ -247,6 +248,46 @@ export default function Home() {
     () => sortDungeons(highlights, lang),
     [highlights, lang],
   );
+  const currentSeason = React.useMemo(() => {
+    return sortedHighlights.reduce((latest, highlight) => {
+      const scoreSeason = highlight?.score?.season ?? null;
+      const timeSeason = highlight?.time?.season ?? null;
+      const candidate = Math.max(scoreSeason || 0, timeSeason || 0);
+      return candidate > latest ? candidate : latest;
+    }, 0);
+  }, [sortedHighlights]);
+
+  React.useEffect(() => {
+    if (loading || error || sortedHighlights.length === 0) {
+      return undefined;
+    }
+    const intervalId = window.setInterval(() => {
+      setCarouselPage((page) => (page + 1) % 2);
+    }, 10000);
+    return () => window.clearInterval(intervalId);
+  }, [loading, error, sortedHighlights.length]);
+
+  React.useEffect(() => {
+    if (loading || error || sortedHighlights.length === 0) {
+      setCarouselPage(0);
+    }
+  }, [loading, error, sortedHighlights.length]);
+
+  const isSeasonPage = carouselPage === 1;
+  const carouselLabel = isSeasonPage
+    ? t.highlightCarouselSeasonLabel ?? 'Current season records'
+    : t.highlightCarouselAllTimeLabel ?? 'All-time records';
+  const displayHighlights = isSeasonPage
+    ? sortedHighlights.map((highlight) => {
+        const scoreMatchesSeason = currentSeason > 0 && highlight?.score?.season === currentSeason;
+        const timeMatchesSeason = currentSeason > 0 && highlight?.time?.season === currentSeason;
+        return {
+          ...highlight,
+          score: scoreMatchesSeason ? highlight.score : null,
+          time: timeMatchesSeason ? highlight.time : null,
+        };
+      })
+    : sortedHighlights;
 
   return (
     <main className="page" aria-labelledby="home-title">
@@ -254,15 +295,24 @@ export default function Home() {
         <span>{pageTitle}</span>
       </h1>
       <section className="highlight-section" aria-live="polite">
+        {!loading && !error && sortedHighlights.length > 0 ? (
+          <div className="highlight-carousel-header">
+            <p className="highlight-carousel-title">{carouselLabel}</p>
+            <div className="highlight-carousel-dots" aria-hidden="true">
+              <span className={`highlight-carousel-dot${carouselPage === 0 ? ' active' : ''}`} />
+              <span className={`highlight-carousel-dot${carouselPage === 1 ? ' active' : ''}`} />
+            </div>
+          </div>
+        ) : null}
         {loading ? (
           <p className="highlight-status">{t.highlightLoading ?? t.leaderboardLoading}</p>
         ) : error ? (
           <p className="highlight-status error">{t.highlightError ?? t.leaderboardError}</p>
-        ) : sortedHighlights.length === 0 ? (
+        ) : displayHighlights.length === 0 ? (
           <p className="highlight-status">{t.highlightEmpty ?? t.leaderboardEmpty}</p>
         ) : (
           <ul className="highlight-list">
-            {sortedHighlights.map((highlight) => {
+            {displayHighlights.map((highlight) => {
               const dungeonName = getDungeonNameForLang(highlight, lang);
               const score = highlight.score;
               const time = highlight.time;

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -197,6 +197,8 @@ export default function Home() {
   const { t, lang } = React.useContext(LangContext);
   const [highlights, setHighlights] = React.useState([]);
   const [carouselPage, setCarouselPage] = React.useState(0);
+  const [carouselDirection, setCarouselDirection] = React.useState('forward');
+  const [carouselAnimationKey, setCarouselAnimationKey] = React.useState(0);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(false);
   const pageTitle = capitaliseWords(t.leaderboardTitle || '');
@@ -273,6 +275,16 @@ export default function Home() {
     }
   }, [loading, error, sortedHighlights.length]);
 
+  React.useEffect(() => {
+    if (loading || error || sortedHighlights.length === 0) {
+      setCarouselDirection('forward');
+      setCarouselAnimationKey(0);
+      return;
+    }
+    setCarouselDirection(carouselPage === 1 ? 'forward' : 'backward');
+    setCarouselAnimationKey((value) => value + 1);
+  }, [carouselPage, loading, error, sortedHighlights.length]);
+
   const isSeasonPage = carouselPage === 1;
   const carouselLabel = isSeasonPage
     ? t.highlightCarouselSeasonLabel ?? 'Current season records'
@@ -311,7 +323,10 @@ export default function Home() {
         ) : displayHighlights.length === 0 ? (
           <p className="highlight-status">{t.highlightEmpty ?? t.leaderboardEmpty}</p>
         ) : (
-          <ul className="highlight-list">
+          <ul
+            key={`${carouselPage}-${carouselAnimationKey}`}
+            className={`highlight-list highlight-list--carousel highlight-list--${carouselDirection}`}
+          >
             {displayHighlights.map((highlight) => {
               const dungeonName = getDungeonNameForLang(highlight, lang);
               const score = highlight.score;

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -199,6 +199,7 @@ export default function Home() {
   const [carouselPage, setCarouselPage] = React.useState(0);
   const [carouselDirection, setCarouselDirection] = React.useState('forward');
   const [carouselAnimationKey, setCarouselAnimationKey] = React.useState(0);
+  const [carouselTimerSeed, setCarouselTimerSeed] = React.useState(0);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(false);
   const pageTitle = capitaliseWords(t.leaderboardTitle || '');
@@ -259,15 +260,23 @@ export default function Home() {
     }, 0);
   }, [sortedHighlights]);
 
+  const changeCarouselPage = React.useCallback((nextPage, manual = false) => {
+    const safePage = nextPage === 1 ? 1 : 0;
+    setCarouselPage(safePage);
+    if (manual) {
+      setCarouselTimerSeed((value) => value + 1);
+    }
+  }, []);
+
   React.useEffect(() => {
     if (loading || error || sortedHighlights.length === 0) {
       return undefined;
     }
-    const intervalId = window.setInterval(() => {
-      setCarouselPage((page) => (page + 1) % 2);
+    const timeoutId = window.setTimeout(() => {
+      changeCarouselPage((carouselPage + 1) % 2, false);
     }, 10000);
-    return () => window.clearInterval(intervalId);
-  }, [loading, error, sortedHighlights.length]);
+    return () => window.clearTimeout(timeoutId);
+  }, [carouselPage, carouselTimerSeed, loading, error, sortedHighlights.length, changeCarouselPage]);
 
   React.useEffect(() => {
     if (loading || error || sortedHighlights.length === 0) {
@@ -279,6 +288,7 @@ export default function Home() {
     if (loading || error || sortedHighlights.length === 0) {
       setCarouselDirection('forward');
       setCarouselAnimationKey(0);
+      setCarouselTimerSeed(0);
       return;
     }
     setCarouselDirection(carouselPage === 1 ? 'forward' : 'backward');
@@ -306,13 +316,38 @@ export default function Home() {
       <h1 id="home-title" className="page-title title-with-icon">
         <span>{pageTitle}</span>
       </h1>
-      <section className="highlight-section" aria-live="polite">
+      <section
+        className="highlight-section"
+        aria-live="polite"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (loading || error || sortedHighlights.length === 0) {
+            return;
+          }
+          if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+            event.preventDefault();
+            changeCarouselPage((carouselPage + 1) % 2, true);
+          }
+        }}
+      >
         {!loading && !error && sortedHighlights.length > 0 ? (
           <div className="highlight-carousel-header">
             <p className="highlight-carousel-title">{carouselLabel}</p>
-            <div className="highlight-carousel-dots" aria-hidden="true">
-              <span className={`highlight-carousel-dot${carouselPage === 0 ? ' active' : ''}`} />
-              <span className={`highlight-carousel-dot${carouselPage === 1 ? ' active' : ''}`} />
+            <div className="highlight-carousel-dots">
+              <button
+                type="button"
+                className={`highlight-carousel-dot${carouselPage === 0 ? ' active' : ''}`}
+                aria-label={t.highlightCarouselAllTimeLabel ?? 'All-time records'}
+                aria-current={carouselPage === 0 ? 'true' : undefined}
+                onClick={() => changeCarouselPage(0, true)}
+              />
+              <button
+                type="button"
+                className={`highlight-carousel-dot${carouselPage === 1 ? ' active' : ''}`}
+                aria-label={t.highlightCarouselSeasonLabel ?? 'Current season records'}
+                aria-current={carouselPage === 1 ? 'true' : undefined}
+                onClick={() => changeCarouselPage(1, true)}
+              />
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
### Motivation
- Présenter les donjons mis en avant sur la page d'accueil sous la forme d'un carrousel à 2 pages pour distinguer les records all-time et ceux de la saison courante.
- Basculer automatiquement entre les deux vues toutes les 10 secondes pour attirer l'attention sur les deux types de records sans interaction utilisateur.

### Description
- Ajout d'un état `carouselPage` et d'un interval d'auto-rotation dans `nwleaderboard-ui/js/pages/Home.js` pour alterner entre les pages toutes les 10 secondes via `setInterval`.
- Calcul de la `currentSeason` à partir des métriques des highlights et génération de `displayHighlights` qui masque les métriques hors-saison sur la page saisonnière (page 2).
- Ajout d'un petit header visuel (label + deux pastilles) au-dessus de la liste pour indiquer la page active et d'un libellé localisable via `t.highlightCarouselSeasonLabel` / `t.highlightCarouselAllTimeLabel`.
- Ajout des styles CSS correspondants dans `nwleaderboard-ui/css/main.css` pour le header du carrousel et les indicateurs de page, sans modification côté API.

### Testing
- Exécution de la construction UI automatisée avec `npm --prefix nwleaderboard-ui run build`, qui a réussi.
- Vérification de l'état de l'arbre de travail montrant les fichiers modifiés et commit effectués avec le nouveau code (build et commit automatisés réussis).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf47ad398832c9c7c9744dc5edd59)