### PR TITLE
Fix empty current-season highlights by returning season metadata

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightMetricResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightMetricResponse.java
@@ -11,6 +11,7 @@ import java.util.List;
 public record HighlightMetricResponse(
         Integer value,
         Integer week,
+        Integer season,
         Integer position,
         List<LeaderboardPlayerResponse> players,
         @JsonProperty("region") String region,

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
@@ -12,6 +12,7 @@ import com.opyruso.nwleaderboard.entity.Player;
 import com.opyruso.nwleaderboard.entity.RunScore;
 import com.opyruso.nwleaderboard.entity.RunTime;
 import com.opyruso.nwleaderboard.entity.WeekMutationDungeon;
+import com.opyruso.nwleaderboard.entity.WeekMutationDungeonId;
 import com.opyruso.nwleaderboard.repository.DungeonRepository;
 import com.opyruso.nwleaderboard.repository.RunScorePlayerRepository;
 import com.opyruso.nwleaderboard.repository.RunScoreRepository;
@@ -286,6 +287,7 @@ public class LeaderboardService {
 
         Map<Long, List<LeaderboardPlayerResponse>> scorePlayersByRun = loadPlayersForScoreRuns(scoreRuns);
         Map<Long, List<LeaderboardPlayerResponse>> timePlayersByRun = loadPlayersForTimeRuns(timeRuns);
+        Map<MutationKey, Integer> seasonsByRunKey = loadSeasonsForRuns(scoreRuns, timeRuns);
 
         List<HighlightResponse> responses = new ArrayList<>();
         for (Dungeon dungeon : highlighted) {
@@ -307,6 +309,7 @@ public class LeaderboardService {
                     ? new HighlightMetricResponse(
                             bestScore.getScore(),
                             bestScore.getWeek(),
+                            resolveSeasonId(bestScore.getWeek(), bestScore.getDungeon(), seasonsByRunKey),
                             scorePosition,
                             scorePlayersByRun.getOrDefault(bestScore.getId(), List.of()),
                             scoreRegion,
@@ -326,6 +329,7 @@ public class LeaderboardService {
                     ? new HighlightMetricResponse(
                             bestTime.getTimeInSecond(),
                             bestTime.getWeek(),
+                            resolveSeasonId(bestTime.getWeek(), bestTime.getDungeon(), seasonsByRunKey),
                             timePosition,
                             timePlayersByRun.getOrDefault(bestTime.getId(), List.of()),
                             timeRegion,
@@ -354,6 +358,48 @@ public class LeaderboardService {
             return collator.compare(leftName, rightName);
         });
         return List.copyOf(responses);
+    }
+
+
+    private Map<MutationKey, Integer> loadSeasonsForRuns(List<RunScore> scoreRuns, List<RunTime> timeRuns) {
+        LinkedHashSet<WeekMutationDungeonId> ids = new LinkedHashSet<>();
+        if (scoreRuns != null) {
+            for (RunScore run : scoreRuns) {
+                if (run == null || run.getWeek() == null || run.getDungeon() == null || run.getDungeon().getId() == null) {
+                    continue;
+                }
+                ids.add(new WeekMutationDungeonId(run.getWeek(), run.getDungeon().getId()));
+            }
+        }
+        if (timeRuns != null) {
+            for (RunTime run : timeRuns) {
+                if (run == null || run.getWeek() == null || run.getDungeon() == null || run.getDungeon().getId() == null) {
+                    continue;
+                }
+                ids.add(new WeekMutationDungeonId(run.getWeek(), run.getDungeon().getId()));
+            }
+        }
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        Map<MutationKey, Integer> result = new HashMap<>();
+        List<WeekMutationDungeon> entries = weekMutationDungeonRepository.listByIds(ids);
+        for (WeekMutationDungeon entry : entries) {
+            if (entry == null || entry.getId() == null) {
+                continue;
+            }
+            MutationKey key = new MutationKey(entry.getId().getWeek(), entry.getId().getDungeonId());
+            Integer seasonId = entry.getSeason() != null ? entry.getSeason().getId() : null;
+            result.put(key, seasonId);
+        }
+        return result;
+    }
+
+    private Integer resolveSeasonId(Integer week, Dungeon dungeon, Map<MutationKey, Integer> seasonsByRunKey) {
+        if (week == null || dungeon == null || dungeon.getId() == null || seasonsByRunKey == null || seasonsByRunKey.isEmpty()) {
+            return null;
+        }
+        return seasonsByRunKey.get(new MutationKey(week, dungeon.getId()));
     }
 
     private Map<Long, List<LeaderboardPlayerResponse>> loadPlayersForScoreRuns(List<RunScore> runs) {


### PR DESCRIPTION
### Motivation
- The Home page carousel filters highlights by `metric.season`, but highlight payloads lacked season context so the UI showed “No score yet / No time yet” despite runs existing.

### Description
- Add `season` to the `HighlightMetricResponse` record so each highlight metric can expose its season (`nwleaderboard-api/src/main/java/.../HighlightMetricResponse.java`).
- Populate metric seasons in `LeaderboardService#getHighlights` by resolving run (week, dungeon) → season and include the field when constructing `HighlightMetricResponse`.
- Resolve seasons in batch using `WeekMutationDungeonRepository.listByIds` and new helpers `loadSeasonsForRuns` and `resolveSeasonId` to avoid per-run lookups and keep responses consistent.
- Add the `WeekMutationDungeonId` import and wire the batch lookup into the highlights construction (`nwleaderboard-api/src/main/java/.../LeaderboardService.java`).

### Testing
- Ran `cd nwleaderboard-api && mvn -q -DskipTests compile` and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfc06d8ec832c88f29c96b9173931)