### PR TITLE
Expose current-season highlights for /leaderboard/highlights and Home carousel

### DIFF
--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightResponse.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightResponse.java
@@ -13,4 +13,6 @@ public record HighlightResponse(
         @JsonProperty("player_count") Integer playerCount,
         @JsonProperty("region") String region,
         @JsonProperty("best_score") HighlightMetricResponse bestScore,
-        @JsonProperty("best_time") HighlightMetricResponse bestTime) {}
+        @JsonProperty("best_time") HighlightMetricResponse bestTime,
+        @JsonProperty("best_score_current_season") HighlightMetricResponse bestScoreCurrentSeason,
+        @JsonProperty("best_time_current_season") HighlightMetricResponse bestTimeCurrentSeason) {}

--- a/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
+++ b/nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java
@@ -18,11 +18,13 @@ import com.opyruso.nwleaderboard.repository.RunScorePlayerRepository;
 import com.opyruso.nwleaderboard.repository.RunScoreRepository;
 import com.opyruso.nwleaderboard.repository.RunTimePlayerRepository;
 import com.opyruso.nwleaderboard.repository.RunTimeRepository;
+import com.opyruso.nwleaderboard.repository.SeasonRepository;
 import com.opyruso.nwleaderboard.repository.WeekMutationDungeonRepository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import java.text.Collator;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,6 +64,9 @@ public class LeaderboardService {
 
     @Inject
     WeekMutationDungeonRepository weekMutationDungeonRepository;
+
+    @Inject
+    SeasonRepository seasonRepository;
 
     @Transactional(Transactional.TxType.SUPPORTS)
     public LeaderboardPageResponse getScoreEntries(
@@ -262,8 +267,12 @@ public class LeaderboardService {
             return List.of();
         }
 
+        Integer currentSeasonId = resolveCurrentSeasonId();
+
         LinkedHashMap<Long, RunScore> bestScoresByDungeon = new LinkedHashMap<>();
         LinkedHashMap<Long, RunTime> bestTimesByDungeon = new LinkedHashMap<>();
+        LinkedHashMap<Long, RunScore> bestCurrentSeasonScoresByDungeon = new LinkedHashMap<>();
+        LinkedHashMap<Long, RunTime> bestCurrentSeasonTimesByDungeon = new LinkedHashMap<>();
         List<RunScore> scoreRuns = new ArrayList<>();
         List<RunTime> timeRuns = new ArrayList<>();
         Map<MutationKey, MutationIds> mutationCache = new HashMap<>();
@@ -278,10 +287,32 @@ public class LeaderboardService {
                 bestScoresByDungeon.put(dungeonId, bestScore);
                 scoreRuns.add(bestScore);
             }
+            if (currentSeasonId != null) {
+                RunScore bestCurrentSeasonScore = runScoreRepository
+                        .listByDungeonAndWeeks(dungeonId, null, null, currentSeasonId, 0, 1)
+                        .stream()
+                        .findFirst()
+                        .orElse(null);
+                if (bestCurrentSeasonScore != null) {
+                    bestCurrentSeasonScoresByDungeon.put(dungeonId, bestCurrentSeasonScore);
+                    scoreRuns.add(bestCurrentSeasonScore);
+                }
+            }
             RunTime bestTime = runTimeRepository.findBestByDungeon(dungeonId);
             if (bestTime != null) {
                 bestTimesByDungeon.put(dungeonId, bestTime);
                 timeRuns.add(bestTime);
+            }
+            if (currentSeasonId != null) {
+                RunTime bestCurrentSeasonTime = runTimeRepository
+                        .listByDungeonAndWeeks(dungeonId, null, null, currentSeasonId, 0, 1)
+                        .stream()
+                        .findFirst()
+                        .orElse(null);
+                if (bestCurrentSeasonTime != null) {
+                    bestCurrentSeasonTimesByDungeon.put(dungeonId, bestCurrentSeasonTime);
+                    timeRuns.add(bestCurrentSeasonTime);
+                }
             }
         }
 
@@ -297,6 +328,8 @@ public class LeaderboardService {
             Long dungeonId = dungeon.getId();
             RunScore bestScore = bestScoresByDungeon.get(dungeonId);
             RunTime bestTime = bestTimesByDungeon.get(dungeonId);
+            RunScore bestCurrentSeasonScore = bestCurrentSeasonScoresByDungeon.get(dungeonId);
+            RunTime bestCurrentSeasonTime = bestCurrentSeasonTimesByDungeon.get(dungeonId);
             MutationIds scoreMutations = resolveMutationIds(
                     bestScore != null ? bestScore.getWeek() : null,
                     bestScore != null ? bestScore.getDungeon() : null,
@@ -340,6 +373,10 @@ public class LeaderboardService {
             Map<String, String> names = buildNameMap(dungeon);
             String fallbackName = names.getOrDefault("en", valueOrEmpty(dungeon.getNameLocalEn()));
             String highlightRegion = resolveHighlightRegion(scoreRegion, timeRegion);
+            HighlightMetricResponse scoreCurrentSeasonMetric = buildHighlightScoreMetric(
+                    bestCurrentSeasonScore, scorePlayersByRun, mutationCache, seasonsByRunKey, currentSeasonId);
+            HighlightMetricResponse timeCurrentSeasonMetric = buildHighlightTimeMetric(
+                    bestCurrentSeasonTime, timePlayersByRun, mutationCache, seasonsByRunKey, currentSeasonId);
             responses.add(new HighlightResponse(
                     dungeonId,
                     fallbackName,
@@ -347,7 +384,9 @@ public class LeaderboardService {
                     dungeon.getPlayerCount(),
                     highlightRegion,
                     scoreMetric,
-                    timeMetric));
+                    timeMetric,
+                    scoreCurrentSeasonMetric,
+                    timeCurrentSeasonMetric));
         }
 
         Collator collator = Collator.getInstance(Locale.ENGLISH);
@@ -360,6 +399,63 @@ public class LeaderboardService {
         return List.copyOf(responses);
     }
 
+
+
+    private Integer resolveCurrentSeasonId() {
+        LocalDate today = LocalDate.now();
+        return seasonRepository.find("dateBegin <= ?1 AND dateEnd >= ?1 ORDER BY id DESC", today)
+                .firstResultOptional()
+                .map(season -> season.getId())
+                .orElse(null);
+    }
+
+    private HighlightMetricResponse buildHighlightScoreMetric(
+            RunScore run,
+            Map<Long, List<LeaderboardPlayerResponse>> playersByRun,
+            Map<MutationKey, MutationIds> mutationCache,
+            Map<MutationKey, Integer> seasonsByRunKey,
+            Integer fallbackSeasonId) {
+        if (run == null) {
+            return null;
+        }
+        MutationIds mutations = resolveMutationIds(run.getWeek(), run.getDungeon(), mutationCache);
+        String region = normaliseRegionId(run.getRegion() != null ? run.getRegion().getId() : null);
+        Integer season = resolveSeasonId(run.getWeek(), run.getDungeon(), seasonsByRunKey);
+        return new HighlightMetricResponse(
+                run.getScore(),
+                run.getWeek(),
+                season != null ? season : fallbackSeasonId,
+                runScoreRepository.findPositionInDungeon(run),
+                playersByRun.getOrDefault(run.getId(), List.of()),
+                region,
+                mutations.typeId(),
+                mutations.promotionId(),
+                mutations.curseId());
+    }
+
+    private HighlightMetricResponse buildHighlightTimeMetric(
+            RunTime run,
+            Map<Long, List<LeaderboardPlayerResponse>> playersByRun,
+            Map<MutationKey, MutationIds> mutationCache,
+            Map<MutationKey, Integer> seasonsByRunKey,
+            Integer fallbackSeasonId) {
+        if (run == null) {
+            return null;
+        }
+        MutationIds mutations = resolveMutationIds(run.getWeek(), run.getDungeon(), mutationCache);
+        String region = normaliseRegionId(run.getRegion() != null ? run.getRegion().getId() : null);
+        Integer season = resolveSeasonId(run.getWeek(), run.getDungeon(), seasonsByRunKey);
+        return new HighlightMetricResponse(
+                run.getTimeInSecond(),
+                run.getWeek(),
+                season != null ? season : fallbackSeasonId,
+                runTimeRepository.findPositionInDungeon(run),
+                playersByRun.getOrDefault(run.getId(), List.of()),
+                region,
+                mutations.typeId(),
+                mutations.promotionId(),
+                mutations.curseId());
+    }
 
     private Map<MutationKey, Integer> loadSeasonsForRuns(List<RunScore> scoreRuns, List<RunTime> timeRuns) {
         LinkedHashSet<WeekMutationDungeonId> ids = new LinkedHashSet<>();

--- a/nwleaderboard-ui/js/pages/Home.js
+++ b/nwleaderboard-ui/js/pages/Home.js
@@ -149,6 +149,12 @@ function normaliseHighlight(entry, index) {
   const playerCount = toPositiveInteger(entry.player_count ?? entry.playerCount);
   const score = normaliseMetric(entry.best_score ?? entry.score ?? entry.bestScore);
   const time = normaliseMetric(entry.best_time ?? entry.time ?? entry.bestTime);
+  const currentSeasonScore = normaliseMetric(
+    entry.best_score_current_season ?? entry.bestScoreCurrentSeason,
+  );
+  const currentSeasonTime = normaliseMetric(
+    entry.best_time_current_season ?? entry.bestTimeCurrentSeason,
+  );
   const region = extractRegionId(entry);
   return {
     id,
@@ -158,6 +164,8 @@ function normaliseHighlight(entry, index) {
     playerCount,
     score,
     time,
+    currentSeasonScore,
+    currentSeasonTime,
     region,
   };
 }
@@ -332,10 +340,12 @@ export default function Home() {
     ? sortedHighlights.map((highlight) => {
         const scoreMatchesSeason = currentSeason > 0 && highlight?.score?.season === currentSeason;
         const timeMatchesSeason = currentSeason > 0 && highlight?.time?.season === currentSeason;
+        const score = highlight?.currentSeasonScore ?? (scoreMatchesSeason ? highlight.score : null);
+        const time = highlight?.currentSeasonTime ?? (timeMatchesSeason ? highlight.time : null);
         return {
           ...highlight,
-          score: scoreMatchesSeason ? highlight.score : null,
-          time: timeMatchesSeason ? highlight.time : null,
+          score,
+          time,
         };
       })
     : sortedHighlights;


### PR DESCRIPTION
### Motivation
- The home carousel's "Current season records" page was empty because the `/leaderboard/highlights` payload only returned all-time bests and no explicit per-dungeon bests for the ongoing season. 
- The API must provide season-constrained best score/time so the front-end can display season records reliably.

### Description
- Extend the highlights DTO by adding `best_score_current_season` and `best_time_current_season` to `HighlightResponse` so the payload can carry season-specific metrics.
- Update `LeaderboardService#getHighlights()` to determine the current season (by `dateBegin <= today <= dateEnd` via `SeasonRepository`) and to fetch the best score/time constrained to that season using `listByDungeonAndWeeks`, while keeping all-time bests unchanged; new helper methods `resolveCurrentSeasonId`, `buildHighlightScoreMetric` and `buildHighlightTimeMetric` were added to keep logic clear.
- Inject `SeasonRepository` into the service and include current-season runs when loading player and season mapping data to compute positions and seasons consistently.
- Update front-end `Home.js` normalization and display logic to read `best_score_current_season` / `best_time_current_season` and to prefer those fields for the carousel with a backward-compatible fallback to the previous behavior.
- Modified files: `nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/dto/HighlightResponse.java`, `nwleaderboard-api/src/main/java/com/opyruso/nwleaderboard/service/LeaderboardService.java`, and `nwleaderboard-ui/js/pages/Home.js`.

### Testing
- Compiled the API module successfully with `cd nwleaderboard-api && mvn -q -DskipTests compile` (success).
- Attempted `./mvnw -q -pl nwleaderboard-api -DskipTests compile` but it failed because the Maven wrapper `./mvnw` is not present in the repo (expected environment difference).
- No automated frontend tests were executed in this change; UI behavior should be validated in integration/manual testing to confirm the carousel displays current-season records as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c05f097f8832c9172b9e780a2fd4d)