### PR TITLE
Migrate Quarkus API to Java 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ file required by the service worker.
 
 ## Back-end (nwleaderboard-api)
 
+The API targets Java 25 and requires a Java 25 JDK for local builds and development.
+
 The Quarkus API serves the static UI and proxies authentication flows to
 Keycloak:
 

--- a/nwleaderboard-api/pom.xml
+++ b/nwleaderboard-api/pom.xml
@@ -7,12 +7,11 @@
   <properties>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-    <quarkus.platform.version>3.10.0</quarkus.platform.version>
+    <quarkus.platform.version>3.33.2</quarkus.platform.version>
     <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
-    <java.version>21</java.version>
+    <maven.compiler.release>25</maven.compiler.release>
+    <java.version>25</java.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
### Motivation
- Upgrade the Quarkus stack to a newer platform release that supports newer Java features. 
- Move the build configuration to target Java 25 so the API can use Java 25 language/runtime features. 
- Make the new Java requirement explicit in the project documentation for local development. 

### Description
- Bumped the Quarkus platform (and plugin) version from `3.10.0` to `3.33.2` in `nwleaderboard-api/pom.xml`. 
- Replaced `maven.compiler.source`/`maven.compiler.target` (21) with `maven.compiler.release` set to `25` and updated `java.version` to `25` in `nwleaderboard-api/pom.xml`. 
- Added a short note to `README.md` indicating the backend now requires a Java 25 JDK for local builds and development. 

### Testing
- Ran `mvn -f nwleaderboard-api/pom.xml validate`, which completed successfully. 
- Attempted `mvn -f nwleaderboard-api/pom.xml -DskipTests package`, which failed in the current environment with `fatal error compiling: error: release version 25 not supported` because only JDK 21 is installed. 
- Conclusion: changes are validated at the POM/validation level, but a Java 25 JDK is required to perform a full compile/package locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315560a3e8832c832b3bf9ce449757)